### PR TITLE
CA-88376: Reset the nbd_mirror_failed flag when disabling mirroring

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -281,6 +281,7 @@ tapdisk_vbd_add_secondary(td_vbd_t *vbd)
 		DPRINTF("Removing secondary image\n");
 		vbd->secondary_mode = TD_VBD_SECONDARY_DISABLED;
 		vbd->secondary = NULL;
+		vbd->nbd_mirror_failed = 0;
 		return 0;
 	}
 


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
