### PR TITLE
CA-84868: Warn when closing/pausing VBD with pending failed requests

### DIFF
--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -828,7 +828,10 @@ tapdisk_control_close_image(struct tapdisk_ctl_conn *conn,
 	}
 
 	if (td_flag_test(vbd->state, TD_VBD_PAUSED))
-		EPRINTF("warning: closing paused VBD %s", vbd->name);
+		EPRINTF("closing paused VBD %s", vbd->name);
+
+	if (!list_empty(&vbd->failed_requests))
+		EPRINTF("closing VBD with failed requests\n");
 
 	if(vbd->nbdserver) {
 	  tapdisk_nbdserver_pause(vbd->nbdserver);

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -800,6 +800,9 @@ tapdisk_vbd_pause(td_vbd_t *vbd)
 
 	INFO("pause completed\n");
 
+	if (!list_empty(&vbd->failed_requests))
+		INFO("warning: failed requests pending\n");
+
 	td_flag_clear(vbd->state, TD_VBD_PAUSE_REQUESTED);
 	td_flag_set(vbd->state, TD_VBD_PAUSED);
 


### PR DESCRIPTION
If a VBD is paused and a request has just failed, the VBD will get
paused with requests left in the failed requests queue; this is not a
bug. Since the VBD is paused failed requests won't be retried until the
VBD is resumed. However, instead of resuming the VBD, the VBD may be
closed. As there are pending requests in the failed requests queue that
aren't retried, tapdisk won't be able to close blktap since the
front-end holds it open as the failed requests haven't been
acknowledged. The front-end utterly considers the failed requests
expired, and tapdisk can close the VBD. Stalling/failing the pause
command until all failed requests have been resolved won't help
VM.migrate.
