### PR TITLE
EA-1158/CP-5952: Remove xenstore paths XAPI waits for during shutdown.

### DIFF
--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -66,7 +66,7 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid,
     err = tap_ctl_connect_send_and_receive(pid, &message, NULL);
     if (err || message.type == TAPDISK_MESSAGE_ERROR) {
 		if (!err)
-			err = message.u.response.error;
+			err = -message.u.response.error;
         /*
          * TODO include more info
          */

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -113,7 +113,7 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
      */
     if (tapdisk_xenblkif_find(domid, devid)) {
         /* TODO log error */
-        return EEXIST;
+        return -EALREADY;
     }
 
     err = tapdisk_xenio_ctx_get(pool, &td_ctx);
@@ -142,7 +142,7 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
     if (td_blkif->ring_n_pages > ARRAY_SIZE(td_blkif->ring_ref)) {
         syslog(LOG_ERR, "too many pages (%u), max %u\n",
                 td_blkif->ring_n_pages, ARRAY_SIZE(td_blkif->ring_ref));
-        err = EINVAL;
+        err = -EINVAL;
         goto fail;
     }
 
@@ -198,7 +198,7 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
             }
         default:
             syslog(LOG_ERR, "unsupported protocol 0x%x\n", td_blkif->proto);
-            err = EPROTONOSUPPORT;
+            err = -EPROTONOSUPPORT;
             goto fail;
     }
 


### PR DESCRIPTION
Also, return EALREADY when already connected to the sring and correct
the error code sign in xenblkif_connect.
