### PR TITLE
CA-113543: Don't spam syslog for benign request failures.

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1127,9 +1127,6 @@ tapdisk_vbd_complete_td_request(td_request_t treq, int res)
 		}
 	}
 
-	if (res != 0)
-		DPRINTF("Res=%d, image->type=%d\n", res, image->type);
-
 	if (res != 0 && image->type == DISK_TYPE_NBD && 
 			((image == vbd->secondary) || 
 			 (image == vbd->retired))) {


### PR DESCRIPTION
This was most likely a debug print added when the NBD funcionality was
implemented. tapdisk either way complains about failed requests
elsewhere.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
