### PR TITLE
Fix 'make clean'

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -95,4 +95,5 @@ clean:
 	rm -rf $(RPM_BUILDDIR)
 	rm -f $(BLKTAP_RPM_SOURCES)
 	rm -f $(STAMP_RPMBUILD)
+	rm -f $(STAMP_CHECKOUT)
 	rm -f $(BLKTAP_SRCTREE)/EXTRAVERSION


### PR DESCRIPTION
Source tree, once unpacked in the build directory is not
cleaned up with make clean.
This is fine for the build system, because it does the builds
in one shot, but during development it is useful to do builds
repeatedly while fixing errors discovered.

Signed-off-by: Germano Percossi <germano.percossi@citrix.com>