### PR TITLE
CA-122162: immediately fail request when reaching 2TiB limit

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -1325,7 +1325,7 @@ reserve_new_block(struct vhd_state *s, uint32_t blk)
 		gap = (s->spp - ((s->next_db + s->bm_secs) % s->spp));
 
 	if (s->next_db + gap > UINT_MAX)
-		return (uint64_t)EIO << 32;
+		return (uint64_t)ENOSPC << 32;
 
 	s->bat.pbw_blk    = blk;
 	s->bat.pbw_offset = s->next_db + gap;
@@ -1511,7 +1511,7 @@ allocate_block(struct vhd_state *s, uint32_t blk)
 	}
 
 	if (next_db > UINT_MAX)
-		return -EIO;
+		return -ENOSPC;
 
 	s->next_db = next_db;
 


### PR DESCRIPTION
When hitting the 2TiB limit, fail the request with ENOSPC instead of
EIO, because tapdisk retries requests that have failed with EIO hoping
that the request will utterly succeeded, which can never happen in our
case.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
