### PR TITLE
CA-130371: don't die of footer/header VHD size mismatch

### DIFF
--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -1038,7 +1038,12 @@ vhd_read_bat(vhd_context_t *ctx, vhd_bat_t *bat)
 	 * sometimes preallocate BAT + batmap for max VHD size, so only read in
 	 * the BAT entries that are in use for curr_size */
 	vhd_blks = ctx->footer.curr_size >> VHD_BLOCK_SHIFT;
-	ASSERT(ctx->header.max_bat_size >= vhd_blks);
+	if (ctx->header.max_bat_size < vhd_blks) {
+        VHDLOG("more VHD blocks (%u) than possible (%u)\n",
+                vhd_blks, ctx->header.max_bat_size);
+        err = -EINVAL;
+        goto fail;
+    }
 	size = vhd_bytes_padded(vhd_blks * sizeof(uint32_t));
 
 	err  = posix_memalign(&buf, VHD_SECTOR_SIZE, size);


### PR DESCRIPTION
There's no need to kill tapdisk via an assertion failure in this case as
there might be an intermittent storage error.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
