### PR TITLE
CP-8081: fix 64-bit build error

### DIFF
--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1136,8 +1136,8 @@ tapdisk_control_disk_info(
 	}
 
     DPRINTF("VBD %d got disk info: sectors=%llu sector size=%ld, info=%d\n",
-			vbd->uuid, vbd->disk_info.size, vbd->disk_info.sector_size,
-			vbd->disk_info.info);
+            vbd->uuid, (unsigned long long)vbd->disk_info.size,
+            vbd->disk_info.sector_size, vbd->disk_info.info);
 out:
     if (!err) {
         response->type = TAPDISK_MESSAGE_DISK_INFO_RSP;

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -521,7 +521,7 @@ tapdisk_nbdserver_newclient_unix(event_id_t id, char mode, void *data)
 {
 	int new_fd = 0;
 	struct sockaddr_un remote;
-	size_t t = sizeof(remote);
+	socklen_t t = sizeof(remote);
 	td_nbdserver_t *server = data;
 
 	ASSERT(server);

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -145,7 +145,7 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
      */
     td_blkif->ring_n_pages = 1 << order;
     if (td_blkif->ring_n_pages > ARRAY_SIZE(td_blkif->ring_ref)) {
-        ERROR("too many pages (%u), max %u\n",
+        ERROR("too many pages (%u), max %lu\n",
                 td_blkif->ring_n_pages, ARRAY_SIZE(td_blkif->ring_ref));
         err = -EINVAL;
         goto fail;


### PR DESCRIPTION
Minor changes (mostly printf format specifiers) due to slightly
different types in 64-bit build.
