### PR TITLE
CA-128872: suspend ring operation on VBD pause

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -895,6 +895,9 @@ tapdisk_vbd_pause(td_vbd_t *vbd)
 	if (vbd->nbdserver)
 		tapdisk_nbdserver_pause(vbd->nbdserver);
 
+	if (vbd->sring)
+		tapdisk_server_mask_event(tapdisk_xenblkif_event_id(vbd->sring), 1);
+
 	err = tapdisk_vbd_quiesce_queue(vbd);
 	if (err)
 		return err;
@@ -965,6 +968,9 @@ resume_failed:
 
 	if (vbd->nbdserver)
 		tapdisk_nbdserver_unpause(vbd->nbdserver);
+
+	if (vbd->sring)
+		tapdisk_server_mask_event(tapdisk_xenblkif_event_id(vbd->sring), 0);
 
 	DBG(TLOG_DBG, "state checked\n");
 

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -238,3 +238,9 @@ fail:
 
     return err;
 }
+
+event_id_t
+tapdisk_xenblkif_event_id(const struct td_xenblkif *blkif)
+{
+	return blkif->ctx->ring_event;
+}

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -178,4 +178,7 @@ tapdisk_xenblkif_destroy(struct td_xenblkif * blkif);
 struct td_xenblkif *
 tapdisk_xenblkif_find(const domid_t domid, const int devid);
 
+event_id_t
+tapdisk_xenblkif_event_id(const struct td_xenblkif *blkif);
+
 #endif /* __TD_BLKIF_H__ */


### PR DESCRIPTION
Pausing the VBD without suspending the operation of the ring leads to
requests being extracted from the ring but not being submitted as the
VBD is paused. The problem in that behaviour is that in SXM tapdisk is
paused before it is closed, so there are requests trapped in tapdisk.
Suspending the operation of the ring when pausing the VBD ensures the
ring is flushed and no requests are extracted from the ring while the
VBD is paused.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
