### PR TITLE
CA-130606: move PAGE_XXX symbols into libtapdisk

### DIFF
--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -49,6 +49,10 @@ typedef struct tapdisk_server {
 
 static tapdisk_server_t server;
 
+unsigned int PAGE_SIZE;
+unsigned int PAGE_MASK;
+unsigned int PAGE_SHIFT;
+
 #define tapdisk_server_for_each_vbd(vbd, tmp)			        \
 	list_for_each_entry_safe(vbd, tmp, &server.vbds, next)
 
@@ -359,6 +363,13 @@ tapdisk_server_signal_handler(int signal)
 int
 tapdisk_server_init(void)
 {
+	unsigned int i = 0;
+
+	PAGE_SIZE = sysconf(_SC_PAGESIZE);
+	PAGE_MASK = ~(PAGE_SIZE - 1);
+
+	for (i = PAGE_SIZE, PAGE_SHIFT = 0; i > 1; i >>= 1, PAGE_SHIFT++);
+
 	memset(&server, 0, sizeof(server));
 	INIT_LIST_HEAD(&server.vbds);
 

--- a/drivers/tapdisk2.c
+++ b/drivers/tapdisk2.c
@@ -30,10 +30,6 @@
 #include "tapdisk-server.h"
 #include "tapdisk-control.h"
 
-unsigned int PAGE_SIZE;
-unsigned int PAGE_MASK;
-unsigned int PAGE_SHIFT;
-
 void tdnbd_fdreceiver_start();
 void tdnbd_fdreceiver_stop();
 
@@ -75,12 +71,6 @@ main(int argc, char *argv[])
 	char *control;
 	int c, err, nodaemon;
 	FILE *out;
-    unsigned int i = 0;
-
-    PAGE_SIZE = sysconf(_SC_PAGESIZE);
-    PAGE_MASK = ~(PAGE_SIZE - 1);
-
-    for (i = PAGE_SIZE, PAGE_SHIFT = 0; i > 1; i >>= 1, PAGE_SHIFT++);
 
 	control  = NULL;
 	nodaemon = 0;


### PR DESCRIPTION
Symbols PAGE_MASK, PAGE_SIZE, and PAGE_SHIFT are defined in tapdisk2.c
which is not compiled into libtapdisk, hence these symbols do not get
defined in the library and that obviously doesn't link.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
