### PR TITLE
CA-136104: Adding better kernel version detection: http://lists.xen.org/...

### DIFF
--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -253,8 +253,12 @@ int tapdisk_linux_version(void)
 		return -errno;
 
 	n = sscanf(uts.release, "%u.%u.%u", &version, &patchlevel, &sublevel);
-	if (n != 3)
-		return -ENOSYS;
+        if (n != 3) {
+                sublevel = 0;
+                n = sscanf(uts.release, "%u.%u", &version, &patchlevel);
+                if (n != 2)
+                        return -ENOSYS;
+        }
 
 	return KERNEL_VERSION(version, patchlevel, sublevel);
 }


### PR DESCRIPTION
...archives/html/xen-devel/2013-12/msg01185.html

This prevents the failing on the call to io_setup with EINVAL. Tapdisk
currently detects kernel version for eventfd by looking for 'x.y.z',
which fails on the newer kernel versions.

Credit goes to James Harper from
http://lists.xen.org/archives/html/xen-devel/2013-12/msg01185.html

Signed-off-by: Antony Messerli antony@mes.ser.li
Reviewed-by: Thanos Makatos thanos.makatos@citrix.com

GitHub: closes #79 on xapi-project/blktap
