### PR TITLE
CA-137990: produce ring statistics in /dev/shm

### DIFF
--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -319,3 +319,102 @@ tapdisk_snprintf(char *buf, int * const off, int * const size,
 	*size -= err;
 	return 0;
 }
+
+void
+shm_init(struct shm *shm) {
+
+    ASSERT(shm);
+
+    shm->path = NULL;
+    shm->fd = -1;
+    shm->mem = NULL;
+    shm->size = 0;
+}
+
+
+int
+shm_destroy(struct shm *shm) {
+
+    int err = 0;
+
+    ASSERT(shm);
+
+    if (shm->mem) {
+        err = munmap(shm->mem, shm->size);
+        if (err == -1) {
+            err = errno;
+            EPRINTF("failed to munmap %s: %s\n", shm->path,
+                    strerror(err));
+            goto out;
+        }
+        shm->mem = NULL;
+    }
+
+    if (shm->fd != -1) {
+        do {
+            err = close(shm->fd);
+            if (err)
+                err = errno;
+        } while (err == EINTR);
+        if (err) {
+            EPRINTF("failed to close %s: %s\n", shm->path, strerror(err));
+            goto out;
+        }
+        shm->fd = -1;
+    }
+
+    if (shm->path) {
+        err = unlink(shm->path);
+        if (err == -1) {
+            err = errno;
+            if (err != ENOENT)
+                goto out;
+        }
+    }
+
+out:
+    return err;
+}
+
+
+int
+shm_create(struct shm *shm) {
+
+    int err;
+
+    ASSERT(shm);
+    ASSERT(shm->path);
+    ASSERT(shm->size);
+
+    shm->fd = open(shm->path, O_CREAT | O_TRUNC | O_RDWR | O_EXCL,
+            S_IRUSR | S_IWUSR);
+    if (shm->fd == -1) {
+        err = errno;
+        EPRINTF("failed to open %s: %s\n", shm->path, strerror(err));
+        goto out;
+    }
+
+    err = ftruncate(shm->fd, shm->size);
+    if (err == -1) {
+        err = errno;
+        EPRINTF("failed to truncate %s: %s\n", shm->path, strerror(err));
+        goto out;
+    }
+
+    shm->mem = mmap(NULL, shm->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+            shm->fd, 0);
+    if (shm->mem == MAP_FAILED) {
+        err = errno;
+        EPRINTF("failed to mmap %s: %s\n", shm->path, strerror(err));
+        goto out;
+    }
+
+out:
+    if (err) {
+        int err2 = shm_destroy(shm);
+        if (err2)
+            EPRINTF("failed to clean up failed shared memory file creation: "
+                    "%s (error ignored)\n", strerror(-err2));
+    }
+    return err;
+}

--- a/drivers/tapdisk-utils.h
+++ b/drivers/tapdisk-utils.h
@@ -20,6 +20,9 @@
 
 #include <inttypes.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #define MAX_NAME_LEN          1000
 #define TD_SYSLOG_IDENT_MAX   32
@@ -46,4 +49,38 @@ uint64_t ntohll(uint64_t);
 int
 tapdisk_snprintf(char *buf, int * const off, int * const size,
 		unsigned int depth,	const char *format, ...);
+
+struct shm
+{
+    char *path;
+    int fd;
+    void *mem;
+    unsigned size;
+};
+
+/**
+ * Initialises a shm structure.
+ */
+void
+shm_init(struct shm *shm);
+
+/**
+ * Creates the file in /dev/shm. The caller must populate the path and size
+ * members of the shm structure passed to this function. Upon successful
+ * completion of this function, the caller can use the shm->mem to write up to
+ * shm.size bytes.
+ *
+ * XXX NB if the file is externally written to, the file size will change so
+ * the caller must cope with it (e.g. manually call ftruncate(2)).
+ */
+int
+shm_create(struct shm *shm);
+
+/**
+ * Destroys the file in /dev/shm. The caller is responsible for deallocating
+ * the path member in struct shm.
+ */
+int
+shm_destroy(struct shm *shm);
+
 #endif

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -48,20 +48,8 @@
 struct td_nbdserver;
 
 struct td_vbd_rrd {
-    /*
-     * file descriptor for the file in /dev/shm
-     */
-    int fd;
 
-    /*
-     * memory address returned by mmap
-     */
-    char *mem;
-
-    /*
-     * /path/to/file in /dev/shm
-     */
-    char *path;
+    struct shm shm;
 
     /*
      * Previous value of td_vbd_handle.errors. We maintain this in order to

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -31,6 +31,7 @@
 #include "td-req.h"
 #include "td-stats.h"
 #include "tapdisk-vbd.h"
+#include "tapdisk-utils.h"
 
 struct td_xenio_ctx;
 struct td_vbd_handle;
@@ -120,6 +121,9 @@ struct td_xenblkif {
      * stats
      */
     struct td_xenblkif_stats stats;
+
+    struct shm shm;
+    time_t last;
 };
 
 /* TODO rename from xenio */
@@ -164,7 +168,7 @@ tapdisk_xenblkif_disconnect(const domid_t domid, const int devid);
  *
  * @param blkif the block interface to destroy
  */
-void
+int
 tapdisk_xenblkif_destroy(struct td_xenblkif * blkif);
 
 /**
@@ -180,5 +184,8 @@ tapdisk_xenblkif_find(const domid_t domid, const int devid);
 
 event_id_t
 tapdisk_xenblkif_event_id(const struct td_xenblkif *blkif);
+
+int
+tapdisk_xenblkif_show_io_ring(struct td_xenblkif *blkif);
 
 #endif /* __TD_BLKIF_H__ */


### PR DESCRIPTION
blkback maintains shared ring statistics in a file in sysfs
(vbd-domid-devid/io_ring). This patch implements the same functionality
in tapdisk: tapdisk exports the same information under a new file in
/dev/shm (e.g /dev/shm/vbd3-domid-devid/io_ring), once every thirty
seconds for performance improvements. NB we don't deal with other
processes touching these files.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
