### PR TITLE
CA-136792: produce blkback-style stats

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,8 @@ AC_CHECK_FUNCS([eventfd])
 
 # AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
+AC_DEFINE(_BLKTAP, 1,
+		  Indicates whether this is an internal or external compilation.)
 AC_CONFIG_FILES([
 Makefile
 lvm/Makefile

--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -420,3 +420,10 @@ out:
     }
     return err;
 }
+
+const long long USEC_PER_SEC = 1000000L;
+
+inline long long timeval_to_us(struct timeval *tv)
+{
+	return ((long long)tv->tv_sec * USEC_PER_SEC) + tv->tv_usec;
+}

--- a/drivers/tapdisk-utils.h
+++ b/drivers/tapdisk-utils.h
@@ -70,6 +70,8 @@ shm_init(struct shm *shm);
  * completion of this function, the caller can use the shm->mem to write up to
  * shm.size bytes.
  *
+ * Returns 0 in success, +errno on failure.
+ *
  * XXX NB if the file is externally written to, the file size will change so
  * the caller must cope with it (e.g. manually call ftruncate(2)).
  */
@@ -79,8 +81,12 @@ shm_create(struct shm *shm);
 /**
  * Destroys the file in /dev/shm. The caller is responsible for deallocating
  * the path member in struct shm.
+ *
+ * Returns 0 in success, +errno on failure.
  */
 int
 shm_destroy(struct shm *shm);
+
+inline long long timeval_to_us(struct timeval *tv);
 
 #endif

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1106,10 +1106,10 @@ tapdisk_vbd_check_state(td_vbd_t *vbd)
 	tapdisk_vbd_produce_rrds(vbd);
 
     /*
-     * FIXME don't ignore return value
+     * TODO don't ignore return value
      */
     list_for_each_entry(blkif, &vbd->rings, entry)
-        tapdisk_xenblkif_show_io_ring(blkif);
+		tapdisk_xenblkif_ring_stats_update(blkif);
 
 	tapdisk_vbd_check_queue_state(vbd);
 

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -125,8 +125,27 @@ struct td_xenblkif {
      */
     struct td_xenblkif_stats stats;
 
-    struct shm shm;
-    time_t last;
+    struct {
+        /**
+         * Root directory of the stats.
+         */
+        char *root;
+
+        /**
+         * Xenbus ring
+         */
+        struct shm io_ring;
+
+        /**
+         * blkback-style stats. We keep all seven of them in a single file
+         * because keeping each one in a separate file requires an entire
+         * page because of mmap(2). The order is: ds_req, f_req, oo_req,
+         * rd_req, rd_sect, wr_req, and wr_sect.
+         */
+        struct shm stats;
+
+        time_t last;
+    } xenvbd_stats;
 
     /**
      * Request buffer cache.
@@ -206,6 +225,10 @@ tapdisk_xenblkif_find(const domid_t domid, const int devid);
 event_id_t
 tapdisk_xenblkif_event_id(const struct td_xenblkif *blkif);
 
+/**
+ * Updates ring stats.
+ */
 int
-tapdisk_xenblkif_show_io_ring(struct td_xenblkif *blkif);
+tapdisk_xenblkif_ring_stats_update(struct td_xenblkif *blkif);
+
 #endif /* __TD_BLKIF_H__ */

--- a/drivers/td-stats.h
+++ b/drivers/td-stats.h
@@ -20,6 +20,8 @@
 #ifndef __TD_STATS_H__
 #define __TD_STATS_H__
 
+#include "blktap3.h"
+
 struct td_xenblkif_stats {
     struct {
         unsigned long long in;
@@ -35,6 +37,8 @@ struct td_xenblkif_stats {
         unsigned long long vbd;
         unsigned long long img;
     } errors;
+
+	struct blkback_stats *xenvbd;
 };
 
 #include "td-blkif.h"

--- a/include/blktap3.h
+++ b/include/blktap3.h
@@ -22,8 +22,84 @@
 #ifndef __BLKTAP_3_H__
 #define __BLKTAP_3_H__
 
+#ifdef _BLKTAP
 #include "compiler.h"
+#endif
 
 #define TAPBACK_CTL_SOCK_PATH       "/var/run/tapback.sock"
+
+
+/**
+ * blkback-style stats
+ */
+struct blkback_stats {
+	/**
+	 * BLKIF_OP_DISCARD, not currently supported in blktap3, should always
+	 * be zero
+	 */
+	unsigned long long st_ds_req;
+
+	/**
+	 * BLKIF_OP_FLUSH_DISKCACHE, not currently supported in blktap3,
+	 * should always be zero
+	 */
+	unsigned long long st_f_req;
+
+	/**
+	 * Increased each time we fail to allocate memory for a internal
+	 * request descriptor in response to a ring request.
+	 */
+	unsigned long long st_oo_req;
+
+	/**
+	 * Received BLKIF_OP_READ requests.
+	 */
+	unsigned long long st_rd_req;
+
+	/**
+	 * Completed BLKIF_OP_READ requests.
+	 */
+	long long st_rd_cnt;
+
+	/**
+	 * Read sectors, after we've forwarded the request to actual storage.
+	 */
+	unsigned long long st_rd_sect;
+
+	/**
+	 * Sum of the request response time of all BLKIF_OP_READ, in us.
+	 */
+	long long st_rd_sum_usecs;
+
+	/**
+	 * Absolute maximum BLKIF_OP_READ response time, in us.
+	 */
+	long long st_rd_max_usecs;
+
+	/**
+	 * Received BLKIF_OP_WRITE requests.
+	 */
+	unsigned long long st_wr_req;
+
+	/**
+	 * Completed BLKIF_OP_WRITE requests.
+	 */
+	long long st_wr_cnt;
+
+	/**
+	 * Write sectors, after we've forwarded the request to actual storage.
+	 */
+	unsigned long long st_wr_sect;
+
+	/**
+	 * Sum of the request response time of all BLKIF_OP_WRITE, in us.
+	 */
+	long long st_wr_sum_usecs;
+
+	/**
+	 * Absolute maximum BLKIF_OP_WRITE response time, in us.
+	 */
+	long long st_wr_max_usecs;
+} __attribute__ ((aligned (8)));
 
 #endif /* __BLKTAP_3_H__ */

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -20,6 +20,8 @@
  * modified.
  */
 
+#include "config.h"
+
 #include "tapback.h"
 #include "xenstore.h"
 #include <xen/io/blkif.h>

--- a/tapback/tapback.c
+++ b/tapback/tapback.c
@@ -37,6 +37,7 @@
 #include <syslog.h>
 #include <time.h>
 
+#include "config.h"
 #include "blktap3.h"
 #include "stdio.h" /* TODO tap-ctl.h needs to include stdio.h */
 #include "tap-ctl.h"


### PR DESCRIPTION
Produce I/O statistics in /dev/shm/vbd3-domid-devid. We use one file for
all seven counters as otherwise we're wasting too much memory. Stats are
updated once every thirty seconds to minimise impact on performance.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
