### PR TITLE
CA-140334: don't complain when tapdisk control socket doesn't exist

### DIFF
--- a/control/tap-ctl-ipc.c
+++ b/control/tap-ctl-ipc.c
@@ -32,6 +32,7 @@
 
 #include "tap-ctl.h"
 #include "blktap2.h"
+#include "compiler.h"
 
 int tap_ctl_debug = 0;
 
@@ -177,9 +178,13 @@ tap_ctl_connect(const char *name, int *sfd)
 
 	err = connect(fd, (const struct sockaddr *)&saddr, sizeof(saddr));
 	if (err) {
-		EPRINTF("couldn't connect to %s: %d\n", name, errno);
+		err = errno;
+		if (likely(err == ENOENT))
+			DPRINTF("couldn't connect to %s: %s\n", name, strerror(err));
+		else
+			EPRINTF("couldn't connect to %s: %s\n", name, strerror(err));
 		close(fd);
-		return -errno;
+		return -err;
 	}
 
 	*sfd = fd;

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #include "tap-ctl.h"
+#include "compiler.h"
 
 int
 tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid,
@@ -97,9 +98,13 @@ tap_ctl_disconnect_xenblkif(const pid_t pid, const domid_t domid,
 	}
 
 out:
-	if (err)
-		EPRINTF("failed to disconnect tapdisk[%d] from the ring: %s\n", pid,
-				strerror(-err));
-
-    return err;
+	if (err) {
+		if (likely(err == -ENOENT))
+			DPRINTF("failed to disconnect tapdisk[%d] from the ring: %s\n",
+					pid, strerror(-err));
+		else
+			EPRINTF("failed to disconnect tapdisk[%d] from the ring: %s\n",
+					pid, strerror(-err));
+	}
+	return err;
 }


### PR DESCRIPTION
tapdisks may be destroyed at any time by the SM, therefore their control
socket might disappear abruptly. This is expected and complaining about
innocuous errors like that complicates debugging.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
