### PR TITLE
Avoid using O_DIRECT

### DIFF
--- a/drivers/block-aio.c
+++ b/drivers/block-aio.c
@@ -131,7 +131,7 @@ int tdaio_open(td_driver_t *driver, const char *name, td_flag_t flags)
 		prv->aio_free_list[i] = &prv->aio_requests[i];
 
 	/* Open the file */
-	o_flags = O_DIRECT | O_LARGEFILE | 
+	o_flags = O_LARGEFILE | 
 		((flags & TD_OPEN_RDONLY) ? O_RDONLY : O_RDWR);
         fd = open(name, o_flags);
 

--- a/drivers/block-ram.c
+++ b/drivers/block-ram.c
@@ -136,7 +136,7 @@ int tdram_open (td_driver_t *driver, const char *name, td_flag_t flags)
 	}
 
 	/* Open the file */
-	o_flags = O_DIRECT | O_LARGEFILE | 
+	o_flags = O_LARGEFILE | 
 		((flags == TD_OPEN_RDONLY) ? O_RDONLY : O_RDWR);
         fd = open(name, o_flags);
 

--- a/drivers/block-vindex.c
+++ b/drivers/block-vindex.c
@@ -209,7 +209,7 @@ vhd_index_load(vhd_index_t *index)
 
 	err = vhdi_open(&index->vhdi,
 			index->bat.index_path,
-			O_RDONLY | O_DIRECT | O_LARGEFILE);
+			O_RDONLY | O_LARGEFILE);
 	if (err)
 		goto fail;
 
@@ -344,7 +344,7 @@ vhd_index_open_file(vhd_index_t *index,
 	if (!path)
 		return -ENOENT;
 
-	ref->fd = open(path, O_RDONLY | O_DIRECT | O_LARGEFILE);
+	ref->fd = open(path, O_RDONLY | O_LARGEFILE);
 	if (ref->fd == -1)
 		return -errno;
 

--- a/drivers/td.c
+++ b/drivers/td.c
@@ -242,7 +242,7 @@ td_create(int type, int argc, char *argv[])
 	if (!buf)
 		return ENOMEM;
 
-	fd = open(name, O_WRONLY | O_DIRECT | O_CREAT | O_TRUNC, 0644);
+	fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	if (fd == -1) {
 		free(buf);
 		return errno;

--- a/vhd/lib/libvhd-journal.c
+++ b/vhd/lib/libvhd-journal.c
@@ -1203,7 +1203,7 @@ vhd_journal_open(vhd_journal_t *j, const char *file, const char *jfile)
 	if (err)
 		goto fail;
 
-	vhd->fd = open(file, O_LARGEFILE | O_RDWR | O_DIRECT);
+	vhd->fd = open(file, O_LARGEFILE | O_RDWR);
 	if (vhd->fd == -1) {
 		err = -errno;
 		goto fail;
@@ -1445,7 +1445,7 @@ vhd_journal_revert(vhd_journal_t *j)
 		return -ENOMEM;
 
 	vhd_close(&j->vhd);
-	j->vhd.fd = open(file, O_RDWR | O_DIRECT | O_LARGEFILE);
+	j->vhd.fd = open(file, O_RDWR | O_LARGEFILE);
 	if (j->vhd.fd == -1) {
 		free(file);
 		return -errno;

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -2517,8 +2517,6 @@ vhd_open(vhd_context_t *ctx, const char *file, int flags)
 		return err;
 
 	oflags = O_LARGEFILE;
-	if (!(flags & VHD_OPEN_CACHED))
-		oflags |= O_DIRECT;
 	if (flags & VHD_OPEN_RDONLY)
 		oflags |= O_RDONLY;
 	if (flags & VHD_OPEN_RDWR)
@@ -3073,7 +3071,7 @@ __vhd_create(const char *name, const char *parent, uint64_t bytes, int type,
 	size = blks << VHD_BLOCK_SHIFT;
 
 	ctx.fd = open(name, O_WRONLY | O_CREAT |
-		      O_TRUNC | O_LARGEFILE | O_DIRECT, 0644);
+		      O_TRUNC | O_LARGEFILE, 0644);
 	if (ctx.fd == -1)
 		return -errno;
 
@@ -3289,7 +3287,7 @@ __raw_read_link(char *filename,
 
 	err = 0;
 	errno = 0;
-	fd = open(filename, O_RDONLY | O_DIRECT | O_LARGEFILE);
+	fd = open(filename, O_RDONLY | O_LARGEFILE);
 	if (fd == -1) {
 		VHDLOG("%s: failed to open: %d\n", filename, -errno);
 		return -errno;

--- a/vhd/lib/vhd-util-check.c
+++ b/vhd/lib/vhd-util-check.c
@@ -1076,7 +1076,7 @@ vhd_util_check_vhd(struct vhd_util_check_ctx *ctx, const char *name)
 		return -EINVAL;
 	}
 
-	fd = open(name, O_RDONLY | O_DIRECT | O_LARGEFILE);
+	fd = open(name, O_RDONLY | O_LARGEFILE);
 	if (fd == -1) {
 		printf("error opening %s\n", name);
 		return -errno;

--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -199,7 +199,7 @@ vhd_util_coalesce_parent(const char *name, int sparse, int progress,
 	}
 
 	if (vhd_parent_raw(&vhd)) {
-		parent_fd = open(pname, O_RDWR | O_DIRECT | O_LARGEFILE, 0644);
+		parent_fd = open(pname, O_RDWR | O_LARGEFILE, 0644);
 		if (parent_fd == -1) {
 			err = -errno;
 			printf("failed to open parent %s: %d\n", pname, err);
@@ -350,7 +350,7 @@ vhd_util_coalesce_load_chain(struct list_head *head,
 		if (raw) {
 			entry->raw = raw;
 			entry->raw_fd = open(next,
-					     O_RDWR | O_DIRECT | O_LARGEFILE);
+					     O_RDWR | O_LARGEFILE);
 			if (entry->raw_fd == -1) {
 				err = -errno;
 				goto out;

--- a/vhd/lib/vhd-util-read.c
+++ b/vhd/lib/vhd-util-read.c
@@ -303,7 +303,7 @@ vhd_dump_headers(const char *name, int hex)
 
 	printf("\n%s appears invalid; dumping headers\n\n", name);
 
-	vhd.fd = open(name, O_DIRECT | O_LARGEFILE | O_RDONLY);
+	vhd.fd = open(name, O_LARGEFILE | O_RDONLY);
 	if (vhd.fd == -1)
 		return -errno;
 

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -722,7 +722,7 @@ vhd_util_scan_open_volume(vhd_context_t *vhd, struct vhd_image *image)
 		return image->error;
 	}
 
-	vhd->fd = open(target->device, O_RDONLY | O_DIRECT | O_LARGEFILE);
+	vhd->fd = open(target->device, O_RDONLY | O_LARGEFILE);
 	if (vhd->fd == -1) {
 		free(vhd->file);
 		vhd->file = NULL;


### PR DESCRIPTION
On newer kernel, opening a file with O_DIRECT may fail with EINVAL,
e.g., Ubuntu 14.04 with Linux 3.13 and ext4.
