### PR TITLE
CA-140516: use /dev/zero as a source of a zeroed piece of memory

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -260,13 +260,13 @@ static void finish_data_transaction(struct vhd_state *, struct vhd_bitmap *);
 
 static struct vhd_state  *_vhd_master;
 static unsigned long      _vhd_zsize;
-static char              *_vhd_zeros;
+static char              *_vhd_zeros = NULL;
 int                       _dev_zero = -1;
 
 static int
 vhd_initialize(struct vhd_state *s)
 {
-    int err;
+	int err;
 
 	if (_vhd_zeros)
 		return 0;
@@ -275,23 +275,27 @@ vhd_initialize(struct vhd_state *s)
 	if (test_vhd_flag(s->flags, VHD_FLAG_OPEN_PREALLOCATE))
 		_vhd_zsize += VHD_BLOCK_SIZE;
 
-    _dev_zero = open("/dev/zero", O_RDONLY);
-    if (unlikely(_dev_zero == -1)) {
-        err = errno;
-        EPRINTF("failed to open /dev/zero: %s\n", strerror(err));
-        return -err;
-    }
+	_dev_zero = open("/dev/zero", O_RDONLY);
+	if (unlikely(_dev_zero == -1)) {
+		err = errno;
+		EPRINTF("failed to open /dev/zero: %s\n", strerror(err));
+		return -err;
+	}
 
 	_vhd_zeros = mmap(NULL, _vhd_zsize, PROT_READ,
 			  MAP_SHARED, _dev_zero, 0);
 	if (_vhd_zeros == MAP_FAILED) {
-        err = errno;
+		int _err;
+		err = errno;
 		EPRINTF("vhd_initialize failed: %s\n", strerror(err));
 		_vhd_zeros = NULL;
 		_vhd_zsize = 0;
-        if (unlikely(close(_dev_zero) == -1))
-            EPRINTF("failed to close /dev/zero: %s (error ignored)\n",
-                    strerror(errno));
+		_err = close(_dev_zero);
+		if (unlikely(_err == -1))
+			EPRINTF("failed to close /dev/zero: %s (error ignored)\n",
+					strerror(errno));
+		else
+			_dev_zero = -1;
 
 		return -err;
 	}
@@ -311,10 +315,14 @@ vhd_free(struct vhd_state *s)
 	_vhd_zsize  = 0;
 	_vhd_zeros  = NULL;
 	_vhd_master = NULL;
-    if (unlikely(close(_dev_zero) == -1))
-            EPRINTF("failed to close /dev/zero: %s (error ignored)\n",
-                strerror(errno));
-    _dev_zero = -1;
+	if (_dev_zero != -1) {
+		int _err = close(_dev_zero);
+		if (unlikely(_err == -1))
+			EPRINTF("failed to close /dev/zero: %s (error ignored)\n",
+					strerror(errno));
+		else
+			_dev_zero = -1;
+	}
 }
 
 static char *


### PR DESCRIPTION
Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
