### PR TITLE
CA-139733: Stop vhd false alarm

### DIFF
--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -243,7 +243,8 @@ void vhd_bat_out(vhd_bat_t *);
 void vhd_batmap_header_in(vhd_batmap_t *);
 void vhd_batmap_header_out(vhd_batmap_t *);
 
-int vhd_validate_footer(vhd_footer_t *footer);
+int vhd_validate_footer(vhd_footer_t *footer,
+                        bool suppress_invalid_footer_warning);
 int vhd_validate_header(vhd_header_t *header);
 int vhd_validate_batmap_header(vhd_batmap_t *batmap);
 int vhd_validate_batmap(vhd_context_t *, vhd_batmap_t *batmap);
@@ -319,7 +320,8 @@ int vhd_macx_encode_location(char *name, char **out, int *outlen);
 int vhd_w2u_encode_location(char *name, char **out, int *outlen);
 
 int vhd_read_footer(vhd_context_t *, vhd_footer_t *, bool use_bkp_footer);
-int vhd_read_footer_at(vhd_context_t *, vhd_footer_t *, off64_t);
+int vhd_read_footer_at(vhd_context_t *, vhd_footer_t *, off64_t,
+                bool suppress_invalid_footer_warning);
 int vhd_read_footer_strict(vhd_context_t *, vhd_footer_t *);
 int vhd_read_header(vhd_context_t *, vhd_header_t *);
 int vhd_read_header_at(vhd_context_t *, vhd_header_t *, off64_t);

--- a/vhd/lib/libvhd-journal.c
+++ b/vhd/lib/libvhd-journal.c
@@ -421,7 +421,7 @@ vhd_journal_add_footer(vhd_journal_t *j)
 	if (off == (off64_t)-1)
 		return -errno;
 
-	err = vhd_read_footer_at(vhd, &footer, off - sizeof(vhd_footer_t));
+	err = vhd_read_footer_at(vhd, &footer, off - sizeof(vhd_footer_t), false);
 	if (err)
 		return err;
 
@@ -436,7 +436,7 @@ vhd_journal_add_footer(vhd_journal_t *j)
 	if (!vhd_type_dynamic(vhd))
 		return 0;
 
-	err = vhd_read_footer_at(vhd, &footer, 0);
+	err = vhd_read_footer_at(vhd, &footer, 0, false);
 	if (err)
 		return err;
 
@@ -660,7 +660,7 @@ __vhd_journal_read_footer(vhd_journal_t *j,
 		return err;
 
 	vhd_footer_in(footer);
-	return vhd_validate_footer(footer);
+	return vhd_validate_footer(footer, false);
 }
 
 static int

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -664,7 +664,7 @@ vhd_util_scan_read_volume_headers(vhd_context_t *vhd, struct vhd_image *image)
 
 	memcpy(&vhd->footer, buf, sizeof(vhd_footer_t));
 	vhd_footer_in(&vhd->footer);
-	err = vhd_validate_footer(&vhd->footer);
+	err = vhd_validate_footer(&vhd->footer, false);
 	if (err) {
 		image->message = "invalid footer";
 		image->error   = err;


### PR DESCRIPTION
Stop complaining the primary footer is invalid during storage motion
since the backup one will be read.  Warning messages when reading backup
one is kept.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
