### PR TITLE
CA-141611: support for write I/O barriers

### DIFF
--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -129,6 +129,9 @@ tapdisk_image_check_request(td_image_t *image, td_vbd_request_t *vreq)
 	info   = &driver->info;
 	rdonly = td_flag_test(image->flags, TD_OPEN_RDONLY);
 
+	if (TD_OP_WRITE_BARRIER == vreq->op)
+		return 0;
+
 	secs = 0;
 
 	if (vreq->iovcnt < 0) {

--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -236,6 +236,10 @@ tapdisk_server_check_vbds(void)
 		tapdisk_vbd_check_state(vbd);
 }
 
+/**
+ * Issues new requests. Returns the number of VBDs that contained new requests
+ * which have been issued.
+ */
 static int
 tapdisk_server_recheck_vbds(void)
 {
@@ -340,7 +344,7 @@ tapdisk_server_iterate(void)
 		tapdisk_server_kick_responses();
 
 		ret = tapdisk_server_recheck_vbds();
-	} while (ret);
+	} while (ret); /* repeat until there are no new requests to issue */
 }
 
 static void

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -139,6 +139,11 @@ struct td_vbd_handle {
 	td_disk_info_t              disk_info;
 
     struct td_vbd_rrd           rrd;
+
+	/**
+	 * Points to a pending write I/O barrier request.
+	 */
+	td_vbd_request_t           *barrier;
 };
 
 #define tapdisk_vbd_for_each_request(vreq, tmp, list)	                \
@@ -229,7 +234,15 @@ int tapdisk_vbd_pause(td_vbd_t *);
 int tapdisk_vbd_resume(td_vbd_t *, const char *);
 void tapdisk_vbd_kick(td_vbd_t *);
 void tapdisk_vbd_check_state(td_vbd_t *);
+
+/**
+ * Checks whether there are new requests and if so it submits them, prodived
+ * that the queue has not been quiesced.
+ *
+ * Returns 1 if new requests have been issued, otherwise it returns 0.
+ */
 int tapdisk_vbd_recheck_state(td_vbd_t *);
+
 void tapdisk_vbd_check_progress(td_vbd_t *);
 void tapdisk_vbd_debug(td_vbd_t *);
 int tapdisk_vbd_start_nbdserver(td_vbd_t *);

--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -74,6 +74,7 @@ extern unsigned int PAGE_SHIFT;
 
 #define TD_OP_READ                   0
 #define TD_OP_WRITE                  1
+#define TD_OP_WRITE_BARRIER          2
 
 #define TD_OPEN_QUIET                0x00001
 #define TD_OPEN_QUERY                0x00002

--- a/include/list.h
+++ b/include/list.h
@@ -21,6 +21,7 @@
 #define __LIST_H__
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #define containerof(_ptr, _type, _memb) \
 	((_type*)((void*)(_ptr) - offsetof(_type, _memb)))
@@ -159,5 +160,19 @@ static inline void list_splice_tail(struct list_head *list,
 
 #define list_first_entry(ptr, type, member) \
 	list_entry((ptr)->next, type, member)
+
+static inline int list_is_singular(const struct list_head *head)
+{
+	return !list_empty(head) && (head->next == head->prev);
+}
+
+/**
+ * Tells whether the list contains exactly this entry.
+ */
+static inline bool list_contains_this_single_entry(struct list_head *list,
+		struct list_head *entry)
+{
+	return list_is_singular(list) && list_is_last(entry, list);
+}
 
 #endif /* __LIST_H__ */

--- a/tapback/frontend.c
+++ b/tapback/frontend.c
@@ -273,14 +273,21 @@ connect_frontend(vbd_t *device) {
 
         /*
          * FIXME blkback writes discard-granularity, discard-alignment,
-         * discard-secure, feature-discard, feature-barrier but we don't.
+         * discard-secure, feature-discard but we don't.
          */
 
         /*
-         * Write the number of sectors, sector size, and info to the
-         * back-end path in XenStore so that the front-end creates a VBD
-         * with the appropriate characteristics.
+		 * Write the number of sectors, sector size, info, and barrier support
+		 * to the back-end path in XenStore so that the front-end creates a VBD
+		 * with the appropriate characteristics.
          */
+        if ((err = tapback_device_printf(device, xst, "feature-barrier", true,
+                        "%d", 1))) {
+            WARN(device, "failed to write feature-barrier: %s\n",
+					strerror(-err));
+            break;
+        }
+
         if ((err = tapback_device_printf(device, xst, "sector-size", true,
                         "%u", device->sector_size))) {
             WARN(device, "failed to write sector-size: %s\n", strerror(-err));


### PR DESCRIPTION
This patch adds support for write I/O barriers. While write I/O barriers
are not strictly required for a guest VM to operate, lack thereof leads
to Linux guests crashing when live-migrating from a host that supports
barriers to one that does not.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
