### PR TITLE
CA-135774: Properly log when low memory handler is not available

### DIFF
--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -618,8 +618,8 @@ tapdisk_server_init(void)
 	scheduler_initialize(&server.scheduler);
 
 	if ((ret = tapdisk_server_initialize_lowmem_mode()) < 0) {
-		ERR(-ret, "Failed to initialize low memory handler: %s\n",
-		    strerror(-ret));
+		EPRINTF("Failed to initialize low memory handler: %s\n",
+		        strerror(-ret));
 		lowmem_cleanup();
 	}
 


### PR DESCRIPTION
Use DPRINTF rather than ERR when logging if the low memory handler is not
available because it is initialized before ERR logging is set up.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
