### PR TITLE
CA-141740: don't overwrite requests not yet submitted

### DIFF
--- a/drivers/td-ctx.c
+++ b/drivers/td-ctx.c
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <alloca.h>
 
 #include "debug.h"
 #include "tapdisk-server.h"
@@ -307,7 +308,11 @@ tapdisk_xenio_ctx_process_ring(struct td_xenblkif *blkif,
          */
         return;
     blkif->stats.reqs.in += n_reqs;
-    reqs = &blkif->reqs_free[blkif->ring_size - start];
+
+    reqs = alloca(sizeof(blkif_request_t*) * n_reqs);
+    memcpy(reqs, &blkif->reqs_free[blkif->ring_size - start],
+            sizeof(blkif_request_t*) * n_reqs);
+
     tapdisk_xenblkif_queue_requests(blkif, reqs, n_reqs);
 }
 


### PR DESCRIPTION
When submitting requests we use a sub-array of the free requests. This
is problematic because if one request fails (e.g. because the grant-copy
failed while serving a write request) we immediately complete the
request, and completing the requests means that we put it back on the
part of the array designated to hold free requests. However, putting
back the request overwrites part of the sub-array designated to the
not-yet-submitted requests, which leads to corruption.

Operating on a copy of the sub-array of the requests to be submitted
addresses the issue.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
