### PR TITLE
CP-9441: debugging improvements

### DIFF
--- a/README
+++ b/README
@@ -117,6 +117,24 @@ or vmdk images:
 xm block-attach 0 tap:qcow:<FILENAME> /dev/xvda1 w 0
 mount /dev/xvda1 /mnt/disk
 
+Debugging
+=========
 
+Valgrind
+--------
+Debugging tapdisk with Valgrind is not straightforward because of the way the
+tapdisk process is spawned, but it can still be achieved by slightly modifying
+a couple of files:
 
- 
+1. Stash `/usr/libexec/tapdisk`, e.g.
+
+~~~
+    mv -f /usr/libexec/tapdisk /usr/libexec/tapdisk~
+~~~
+
+2. Create a new script in its place with following contents:
+
+~~~
+    #!/bin/bash
+    exec valgrind --log-file=/tmp/tapdisk-%p --track-origins=yes /usr/libexec/tapdisk~
+~~~

--- a/control/tap-ctl-create.c
+++ b/control/tap-ctl-create.c
@@ -38,7 +38,7 @@ tap_ctl_create(const char *params, char **devname, int flags, int parent_minor,
 	if (err)
 		return err;
 
-	id = tap_ctl_spawn();
+	id = tap_ctl_spawn(false);
 	if (id < 0) {
 		err = id;
 		goto destroy;

--- a/control/tap-ctl.c
+++ b/control/tap-ctl.c
@@ -389,7 +389,7 @@ usage:
 static void
 tap_cli_spawn_usage(FILE *stream)
 {
-	fprintf(stream, "usage: spawn\n");
+	fprintf(stream, "usage: spawn <-D don't daemonise>\n");
 }
 
 static int
@@ -397,19 +397,23 @@ tap_cli_spawn(int argc, char **argv)
 {
 	int c, tty;
 	pid_t pid;
+	bool nodaemon = false;
 
 	optind = 0;
-	while ((c = getopt(argc, argv, "h")) != -1) {
+	while ((c = getopt(argc, argv, "hD")) != -1) {
 		switch (c) {
 		case '?':
 			goto usage;
+		case 'D':
+			nodaemon = true;
+			break;
 		case 'h':
 			tap_cli_spawn_usage(stdout);
 			return 0;
 		}
 	}
 
-	pid = tap_ctl_spawn();
+	pid = tap_ctl_spawn(nodaemon);
 	if (pid < 0)
 		return pid;
 

--- a/include/tap-ctl.h
+++ b/include/tap-ctl.h
@@ -23,6 +23,7 @@
 #include <sys/time.h>
 #include <tapdisk-message.h>
 #include <list.h>
+#include <stdbool.h>
 
 #include <xen/xen.h>
 #include <xen/grant_table.h>
@@ -96,7 +97,7 @@ int tap_ctl_create(const char *params, char **devname, int flags,
 int tap_ctl_destroy(const int id, const int minor, int force,
 		    struct timeval *timeout);
 
-int tap_ctl_spawn(void);
+int tap_ctl_spawn(const bool nodaemon);
 pid_t tap_ctl_get_pid(const int id);
 
 int tap_ctl_attach(const int id, const int minor);


### PR DESCRIPTION
Option to make tapdisk not daemonise itself, this makes debugging with
valgrind much easier.

Also, documentation on how to debug tapdisk with Valgrind.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
