### PR TITLE
CP-9457: write tapdisk PID in kthread-pid

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -341,6 +341,14 @@ physical_device_changed(vbd_t *device) {
         goto out;
     }
 
+	err = tapback_device_printf(device, XBT_NULL, "kthread-pid", false, "%d",
+		device->tap->pid);
+	if (unlikely(err)) {
+		WARN(device, "warning: failed to write kthread-pid: %s\n",
+				strerror(-err));
+		goto out;
+	}
+
     if (device->sector_size & 0x1ff || device->sectors <= 0) {
         WARN(device, "warning: unexpected device characteristics: sector "
                 "size=%d, sectors=%llu\n", device->sector_size,


### PR DESCRIPTION
This imitates blkback, allowing other components to use the process ID
of the application responsible for the data path as they please, e.g.
the toolstack using ionice(1) for QoS.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
