### PR TITLE
CA-144882: ignore ENOENT error when cleaning up the stats file

### DIFF
--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -365,10 +365,12 @@ shm_destroy(struct shm *shm) {
 
     if (shm->path) {
         err = unlink(shm->path);
-        if (err == -1) {
+        if (unlikely(err == -1)) {
             err = errno;
-            if (err != ENOENT)
+            if (unlikely(err != ENOENT))
                 goto out;
+            else
+                err = 0;
         }
     }
 

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -184,9 +184,11 @@ tapdisk_xenblkif_destroy(struct td_xenblkif * blkif)
     }
 
     err = tapdisk_xenblkif_show_io_ring_destroy(blkif);
-    if (err)
+    if (err) {
         EPRINTF("failed to clean up ring stats file: %s (error ignored)\n",
                 strerror(-err));
+        err = 0;
+    }
 
     free(blkif);
 


### PR DESCRIPTION
Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
