### PR TITLE
CA-145273: don't push responses for dead rings

### DIFF
--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -641,7 +641,7 @@ tapdisk_xenblkif_queue_requests(struct td_xenblkif * const blkif,
         }
     }
 
-    if (nr_errors)
+    if (nr_errors && !blkif->dead)
         xenio_blkif_put_response(blkif, NULL, 0, 1);
 }
 


### PR DESCRIPTION
Pushing responses for dead rings is useless, there is no one interested
for that response and we _know_ pushing the response will fail with an
error being logged.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
