### PR TITLE
CA-145685: Fix size and offset for read requests

### DIFF
--- a/drivers/block-aio.c
+++ b/drivers/block-aio.c
@@ -180,8 +180,8 @@ void tdaio_queue_read(td_driver_t *driver, td_request_t treq)
 	struct tdaio_state *prv;
 
 	prv    = (struct tdaio_state *)driver->data;
-	size   = treq.secs * driver->info.sector_size;
-	offset = treq.sec  * (uint64_t)driver->info.sector_size;
+	size   = treq.secs * SECTOR_SIZE;
+	offset = treq.sec  * (uint64_t)SECTOR_SIZE;
 
 	if (prv->aio_free_count == 0)
 		goto fail;

--- a/drivers/tapdisk-driver.h
+++ b/drivers/tapdisk-driver.h
@@ -25,6 +25,7 @@
 
 #define TD_DRIVER_OPEN               0x0001
 #define TD_DRIVER_RDONLY             0x0002
+#define SECTOR_SIZE                  512
 
 struct td_driver_handle {
 	int                          type;


### PR DESCRIPTION
First draft to fix the size and offset for read requests that are performed against a physical CD/DVD drive.

Considering several ways to improve this PR:
-Define a constant to replace the concrete value '512' - done
-Perform similar modifications for write requests, for consistency reasons - TBD separately
-Investigate whether other lines of code require similar modifications - TBD separately

Thanks.

Signed-off-by: Flavien Quesnel flavien.quesnel@citrix.com
