### PR TITLE
CA-146652: xen-ringwatch generates too many false positives in crit.log

### DIFF
--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -512,10 +512,10 @@ tapdisk_xenblkif_ring_stats_update(struct td_xenblkif *blkif)
     ASSERT(blkif->xenvbd_stats.io_ring.mem);
 
     /*
-     * Update the ring stats once every five seconds.
+     * Update the ring stats once every three seconds.
      */
     t = time(NULL);
-	if (t - blkif->xenvbd_stats.last < 5)
+	if (t - blkif->xenvbd_stats.last < 3)
 		return 0;
 	blkif->xenvbd_stats.last = t;
 


### PR DESCRIPTION
The problem arises because tapdisk3 updates a VBD's ring stats file every 5
seconds, while xen-ringwatch expects pending requests to have been completed in
1 second. This results in notifications of unserviced requests being generated
in crit.log. To address the problem we need to guarantee that 'stats' is
updated at least once per xen-ringwatch call. Thus, tapdisk3's 'stats' update
interval is lowered to 3 seconds and xen-ringwatch's window is raised to 4
seconds.

In xen-4.4.hg/tools/misc/xen-ringwatch:
\-   DEFAULT_PERIOD = 1 # secs
\+   DEFAULT_PERIOD = 4 # secs

Signed-off-by: Kostas Ladopoulos <Konstantinos.Ladopoulos@citrix.com>