### PR TITLE
CA-153279: don't complain if there's no tapdisk to signal

### DIFF
--- a/drivers/blktap
+++ b/drivers/blktap
@@ -5,6 +5,6 @@
     nocreate
     sharedscripts
     postrotate
-               /usr/bin/killall -HUP tapdisk
+               /usr/bin/killall -q -HUP tapdisk
     endscript
 }


### PR DESCRIPTION
When rotating tapdisk logs we blindly tell all tapdisks (even if no
tapdisk exists) to refresh their logs. If no tapdisk exists, an error
message will be logged in /root/dead.letter, which might lead to dom0
root file-system free space implications.

Signed-off-by: Thanos Makatos <thanos.makatos@citrix.com>