### PR TITLE
CA-149898: Add compiler.h to blktap-headers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -18,6 +18,6 @@ blktap_HEADERS += tapdisk-message.h
 blktap_HEADERS += tap-ctl.h
 blktap_HEADERS += debug.h
 blktap_HEADERS += util.h
+blktap_HEADERS += compiler.h
 
 noinst_HEADERS  = blktap.h
-noinst_HEADERS += compiler.h


### PR DESCRIPTION
This change ensures that the blktap-devel RPM packages 'compiler.h'

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
