### PR TITLE
CA-148137: don't free NBD client if there are pending requests, plus unit tests

### DIFF
--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -59,13 +59,11 @@ struct td_nbdserver_req {
 	struct td_iovec         iov;
 };
 
-static void tapdisk_nbdserver_free_client(td_nbdserver_client_t *client);
 static void tapdisk_nbdserver_disable_client(td_nbdserver_client_t *client);
-static void tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data);
 int tapdisk_nbdserver_setup_listening_socket(td_nbdserver_t *server);
 int tapdisk_nbdserver_unpause(td_nbdserver_t *server);
 
-static td_nbdserver_req_t *
+td_nbdserver_req_t *
 tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 {
 	td_nbdserver_req_t *req = NULL;
@@ -76,7 +74,7 @@ tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 	return req;
 }
 
-static void
+void
 tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
 		td_nbdserver_req_t *req)
 {
@@ -110,7 +108,7 @@ tapdisk_nbdserver_reqs_free(td_nbdserver_client_t *client)
 	}
 }
 
-static int
+int
 tapdisk_nbdserver_reqs_init(td_nbdserver_client_t *client, int n_reqs)
 {
 	int i, err;
@@ -149,7 +147,7 @@ fail:
 	return err;
 }
 
-static td_nbdserver_client_t *
+td_nbdserver_client_t *
 tapdisk_nbdserver_alloc_client(td_nbdserver_t *server)
 {
 	td_nbdserver_client_t *client = NULL;
@@ -192,7 +190,7 @@ fail:
 	return client;
 }
 
-static void
+void
 tapdisk_nbdserver_free_client(td_nbdserver_client_t *client)
 {
 	INFO("Free client");
@@ -315,7 +313,7 @@ finish:
 
 static void tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd);
 
-static void
+void
 tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 {
 	td_nbdserver_client_t *client = data;
@@ -837,4 +835,18 @@ tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client) {
 	ASSERT(client);
 
 	return client->n_reqs - client->n_reqs_free;
+}
+
+bool
+tapdisk_nbdserver_contains_client(td_nbdserver_t *server,
+		td_nbdserver_client_t *client) {
+
+	td_nbdserver_client_t *_client;
+
+	ASSERT(server);
+
+	list_for_each_entry(_client, &server->clients, clientlist)
+		if (client == _client)
+			return true;
+	return false;
 }

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -103,6 +103,32 @@ void tapdisk_nbdserver_pause(td_nbdserver_t *);
 int tapdisk_nbdserver_unpause(td_nbdserver_t *);
 
 /**
+ * Callback to be executed when the client socket becomes ready. It is the core
+ * NBD server function that deals with NBD client requests (e.g. I/O read,
+ * I/O write, disconnect, etc.).
+ */
+void tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data);
+int tapdisk_nbdserver_reqs_init(td_nbdserver_client_t *client, int n_reqs);
+
+/**
+ * Deallocates the NBD client. If the client has pending requests, the client
+ * is not deallocated but simply marked as "dead", the last pending request to
+ * complete will actually deallocate it.
+ */
+void tapdisk_nbdserver_free_client(td_nbdserver_client_t *client);
+td_nbdserver_client_t *tapdisk_nbdserver_alloc_client(td_nbdserver_t *server);
+
+/**
+ * Tells whether the NBD client is being server by the NBD server.
+ */
+bool tapdisk_nbdserver_contains_client(td_nbdserver_t *server,
+		td_nbdserver_client_t *client);
+td_nbdserver_req_t *tapdisk_nbdserver_alloc_request(
+		td_nbdserver_client_t *client);
+void tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
+		td_nbdserver_req_t *req);
+
+/**
  * Tells how many requests are pending.
  */
 int tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client);

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -27,6 +27,7 @@ typedef struct td_nbdserver_client td_nbdserver_client_t;
 #include "list.h"
 #include "tapdisk-nbd.h"
 #include <sys/un.h>
+#include <stdbool.h>
 
 struct td_nbdserver {
 	td_vbd_t               *vbd;
@@ -81,6 +82,8 @@ struct td_nbdserver_client {
 	struct list_head        clientlist;
 
 	int                     paused;
+
+	bool                    dead;
 };
 
 td_nbdserver_t *tapdisk_nbdserver_alloc(td_vbd_t *, td_disk_info_t);
@@ -98,5 +101,10 @@ int tapdisk_nbdserver_listen_unix(td_nbdserver_t *server);
 void tapdisk_nbdserver_free(td_nbdserver_t *);
 void tapdisk_nbdserver_pause(td_nbdserver_t *);
 int tapdisk_nbdserver_unpause(td_nbdserver_t *);
+
+/**
+ * Tells how many requests are pending.
+ */
+int tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client);
 
 #endif /* _TAPDISK_NBDSERVER_H_ */

--- a/tests/test_nbdserver.c
+++ b/tests/test_nbdserver.c
@@ -1,0 +1,88 @@
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif /*_LARGEFILE64_SOURCE */
+#include <sys/types.h>
+
+#include "unity.h"
+
+#include <string.h>
+#include <assert.h>
+#include <uuid/uuid.h>
+#include <stdlib.h>
+
+#include "drivers/tapdisk-nbdserver.h"
+
+#include "mock_tapdisk-log.h"
+#include "mock_tapdisk-server.h"
+#include "mock_tapdisk-utils.h"
+#include "mock_tapdisk-vbd.h"
+#include "mock_tapdisk-fdreceiver.h"
+
+unsigned PAGE_SIZE = 1 << 12;
+
+td_nbdserver_t server;
+td_nbdserver_client_t *client;
+
+void setUp(void) {
+
+	tlog_syslog_Ignore();
+	tapdisk_server_unregister_event_Ignore();
+
+	memset(&server, 0, sizeof server);
+	INIT_LIST_HEAD(&server.clients);
+
+	/*
+	 * XXX We leak client as it is complicated to deallocate it in tearDown():
+	 * whether client is deallocated by a test depends on the test itself and
+	 * whether the test succeeds or fails.
+	 */
+	client = tapdisk_nbdserver_alloc_client(&server);
+	assert(client);
+
+}
+
+void tearDown(void) {
+}
+
+void test_nbdserver_client(void) {
+
+	TEST_ASSERT_TRUE_MESSAGE(
+			tapdisk_nbdserver_contains_client(&server, client),
+			"A just-allocated client should be present in the server's list "
+			"of clients");
+
+	TEST_ASSERT_FALSE_MESSAGE(client->dead,
+			"A just-allocated client should not be marked dead.");
+}
+
+void test_nbdserver_client_free(void) {
+
+	tapdisk_nbdserver_free_client(client);
+
+	TEST_ASSERT_FALSE_MESSAGE(
+			tapdisk_nbdserver_contains_client(&server, client),
+			"Freeing a client with no pending requests should result in the "
+			"client being immediately freed.");
+}
+
+void test_nbdserver_client_pending_req(void)
+{
+	td_nbdserver_req_t *req;
+
+	req = tapdisk_nbdserver_alloc_request(client);
+	assert(req);
+
+	tapdisk_nbdserver_clientcb(0, 0, client);
+
+	TEST_ASSERT_TRUE_MESSAGE(
+			tapdisk_nbdserver_contains_client(&server, client),
+			"NBD client shouldn't be freed while there are pending requests");
+	TEST_ASSERT_TRUE_MESSAGE(client->dead, "NBD client should be marked dead");
+
+	tapdisk_nbdserver_free_request(client, req);
+
+	TEST_ASSERT_TRUE_MESSAGE(
+		tapdisk_nbdserver_contains_client(&server, client),
+		"NBD client marked dead should be freed when last request completes");
+}
+


### PR DESCRIPTION
This patch fixes a bug where we blindly deallocate the NBD client without
checking whether there are pending requests. We address this issue by
marking the client as "dead" and letting the last pending request to
complete to deallocate it.