### PR TITLE
Use PRIu64 for uint64_t in format strings

### DIFF
--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -290,7 +290,7 @@ xenio_blkif_put_response(struct td_xenblkif * const blkif,
             if (err < 0) {
                 err = -errno;
                 if (req) {
-                    RING_ERR(blkif, "req %lu: failed to notify event channel: "
+                    RING_ERR(blkif, "req %" PRIu64 ": failed to notify event channel: "
                             "%s\n", req->msg.id, strerror(-err));
                 } else {
                     RING_ERR(blkif, "failed to notify event channel: %s\n",
@@ -386,7 +386,7 @@ guest_copy2(struct td_xenblkif * const blkif,
 			 * xen/extras/mini-os/include/gnttab.h (header not available to
 			 * user space)
 			 */
-			RING_ERR(blkif, "req %lu: failed to grant-copy segment %d: %d\n",
+			RING_ERR(blkif, "req %" PRIu64 ": failed to grant-copy segment %d: %d\n",
                     tapreq->msg.id, i, gcopy_seg->status);
 			err = -EIO;
 			goto out;
@@ -458,7 +458,7 @@ tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
 				_err = guest_copy2(blkif, tapreq);
 				if (unlikely(_err)) {
 					err = _err;
-					RING_ERR(blkif, "req %lu: failed to copy from/to guest: "
+					RING_ERR(blkif, "req %" PRIu64 ": failed to copy from/to guest: "
 							"%s\n", tapreq->msg.id, strerror(-err));
 				}
 			}
@@ -591,7 +591,7 @@ tapdisk_xenblkif_parse_request(struct td_xenblkif * const blkif,
          * must be transferred.
          */
         if (seg->last_sect < seg->first_sect) {
-            RING_ERR(blkif, "req %lu: invalid sectors %d-%d\n",
+            RING_ERR(blkif, "req %" PRIu64 ": invalid sectors %d-%d\n",
                     req->msg.id, seg->first_sect, seg->last_sect);
             err = EINVAL;
             goto out;
@@ -639,7 +639,7 @@ tapdisk_xenblkif_parse_request(struct td_xenblkif * const blkif,
     if (blkif_rq_wr(&req->msg)) {
         err = guest_copy2(blkif, req);
         if (err) {
-            RING_ERR(blkif, "req %lu: failed to copy from guest: %s\n",
+            RING_ERR(blkif, "req %" PRIu64 ": failed to copy from guest: %s\n",
                     req->msg.id, strerror(-err));
             goto out;
         }
@@ -702,7 +702,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
         vreq->op = TD_OP_WRITE;
         break;
     default:
-        RING_ERR(blkif, "req %lu: invalid request type %d\n",
+        RING_ERR(blkif, "req %" PRIu64 ": invalid request type %d\n",
                 tapreq->msg.id, tapreq->msg.operation);
         err = EOPNOTSUPP;
         goto out;
@@ -714,7 +714,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
     if (unlikely((tapreq->msg.nr_segments == 0 &&
                 tapreq->msg.operation != BLKIF_OP_WRITE_BARRIER) ||
             tapreq->msg.nr_segments > BLKIF_MAX_SEGMENTS_PER_REQUEST)) {
-        RING_ERR(blkif, "req %lu: bad number of segments in request (%d)\n",
+        RING_ERR(blkif, "req %" PRIu64 ": bad number of segments in request (%d)\n",
                 tapreq->msg.id, tapreq->msg.nr_segments);
         err = EINVAL;
         goto out;


### PR DESCRIPTION
The format string %lu is for unsigned long, whose width is architecture-
dependent. For fixed-width uint64_t, we should use PRIu64 from <inttypes.h>.

This fixes the build on 32-bit systems.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>