### PR TITLE
CA-169052: Work arounds for NULL uuid in VHD header

### DIFF
--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -2730,6 +2730,10 @@ vhd_initialize_header(vhd_context_t *ctx, const char *parent_path,
 
 		ctx->header.prt_ts = vhd_time(stats.st_mtime);
 		uuid_copy(ctx->header.prt_uuid, parent.footer.uuid);
+		if (uuid_is_null(ctx->header.prt_uuid)) {
+			vhd_close(&parent);
+			return -EINVAL;
+		}
 		*psize = parent.footer.curr_size;
 		if (!size)
 			size = *psize;

--- a/vhd/lib/vhd-util-check.c
+++ b/vhd/lib/vhd-util-check.c
@@ -297,6 +297,9 @@ ok:
 				 sizeof(footer->reserved)))
 		return "invalid 'reserved' bits";
 
+	if (uuid_is_null(footer->uuid))
+		return "invalid (NULL) uuid";
+
 	return NULL;
 }
 

--- a/vhd/lib/vhd-util-repair.c
+++ b/vhd/lib/vhd-util-repair.c
@@ -64,6 +64,14 @@ vhd_util_repair(int argc, char **argv)
 		return err;
 	}
 
+	err = vhd_get_footer(&vhd);
+	if (err) {
+		printf("error reading footer %s: %d\n", name, err);
+		return err;
+	}
+	if (uuid_is_null(vhd.footer.uuid))
+		uuid_generate(vhd.footer.uuid);
+
 	err = vhd_write_footer(&vhd, &vhd.footer);
 	if (err)
 		printf("error writing footer: %d\n", err);


### PR DESCRIPTION
The qemu-img convert -O vpc function used to set a NULL uuid.
This fix ensures that vhd-util repair will set a valid UUID in
the footer.

Signed-off-by: Bob Ball <bob.ball@citrix.com>