### PR TITLE
CP-10070: report read caching status in tap-ctl stat

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1757,6 +1757,8 @@ tapdisk_vbd_stats(td_vbd_t *vbd, td_stats_t *st)
 {
 	td_image_t *image, *next;
     struct td_xenblkif *blkif;
+	const bool read_caching =
+		TD_OPEN_NO_O_DIRECT == (vbd->flags & TD_OPEN_NO_O_DIRECT);
 
 	tapdisk_stats_enter(st, '{');
 	tapdisk_stats_field(st, "name", "s", vbd->name);
@@ -1798,6 +1800,10 @@ tapdisk_vbd_stats(td_vbd_t *vbd, td_stats_t *st)
 	tapdisk_stats_field(st,
 			"reqs_oustanding",
 			"d", tapdisk_vbd_reqs_outstanding(vbd));
+
+	tapdisk_stats_field(st,
+			"read_caching",
+			"s",  read_caching ? "true": "false");
 
 	tapdisk_stats_leave(st, '}');
 }


### PR DESCRIPTION
Having discussed with various people, having the read caching status reported by tap-ctl stats provide a handy way of asserting whether the feature is being used. Several XenRT tests actually rely on this functionality for testing purposes. Merging this commit will close CA-167479.

Signed-off-by: Thanos Makatos <thanos.makatos@citrix.com>
Reviewed-by: Felipe Franciosi <felipe.franciosi@citrix.com>

GitHub: closes #143 on xapi-project/blktap