### PR TITLE
CP-12399: Prevent tapback from plugging non-blktap2 devices

### DIFF
--- a/include/blktap3.h
+++ b/include/blktap3.h
@@ -27,7 +27,7 @@
 #endif
 
 #define TAPBACK_CTL_SOCK_PATH       "/var/run/tapback.sock"
-
+#define BLKTAP2_DEVNAME             "tapdev"
 
 /**
  * blkback-style stats

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -29,6 +29,8 @@
 #include <signal.h>
 #include <stdlib.h>
 
+extern int tapdev_major;
+
 /**
  * Removes the XenStore watch from the front-end.
  *
@@ -303,6 +305,12 @@ physical_device_changed(vbd_t *device) {
         WARN(device, "changing physical device from %x:%x to %x:%x not "
                 "supported\n", device->major, device->minor, major, minor);
         err = -ENOSYS;
+        goto out;
+    }
+
+    if (major != tapdev_major) {
+        WARN(device, "ignoring non-blktap2 physical device: %d\n", major);
+        err = -EINVAL;
         goto out;
     }
 

--- a/tapback/tapback.c
+++ b/tapback/tapback.c
@@ -46,6 +46,7 @@
 
 const char tapback_name[] = "tapback";
 unsigned log_level;
+int tapdev_major;
 
 LIST_HEAD(backends);
 
@@ -460,6 +461,32 @@ tapback_backend_run(backend_t *backend)
     return err;
 }
 
+static int
+get_tapdev_major()
+{
+    FILE *devices;
+    char buf[128], name[128];
+    int major, err = -ENODEV;
+
+    devices = fopen("/proc/devices", "r");
+    if (!devices)
+        return -errno;
+
+    while (fgets(buf, sizeof(buf), devices)){
+        memset(name, 0, sizeof(name));
+        if (sscanf(buf, "%d %127c", &major, name) == 2){
+            if (!strcmp(name, BLKTAP2_DEVNAME"\n")){
+                tapdev_major = major;
+                err = 0;
+                break;
+            }
+        }
+    }
+
+    fclose(devices);
+    return err;
+}
+
 /**
  * Print tapback's usage instructions.
  */
@@ -547,6 +574,13 @@ int main(int argc, char **argv)
 		err = EINVAL;
 		goto fail;
 	}
+
+    if (get_tapdev_major()) {
+        WARN(NULL, "Unable to find blktap2 device major\n");
+        err = EINVAL;
+        goto fail;
+    }
+    DBG(NULL, "Identified blktap2 device major = %d\n", tapdev_major);
 
     prog = basename(argv[0]);
 


### PR DESCRIPTION
With the introduction of tapdisk3, the LUN-per-VDI SRs will either fail or
cause the wrong VDI to be plugged to guests. That is because the SM will
create a block device on /dev/sm/backend/<sr_uuid>/<vdi_uuid> that actually
uses the major/minor number of the actual (raw and block) VDI (instead of the
corresponding blktap2 block device as in releases before Creedence).
    
This patch makes tapback ignore all physical-device entries that do not have
the major number matching the blktap2 major. It therefore prevents VMs from
getting the wrong virtual disk.
    
Separate commits (to the toolstack and to the SM) will make the SM instruct
the toolstack to write on the .../vbd/... xenstore path (instead of /vbd3/)
for such VDI types.
    
Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>
Reviewed-by: Stefano Panella <stefano.panella@citrix.com>