### PR TITLE
CA-170614: Harden the nbdserver code in tapdisk3

### DIFF
--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -51,7 +51,16 @@
  */
 
 #define INFO(_f, _a...)            tlog_syslog(TLOG_INFO, "nbd: " _f, ##_a)
-#define ERROR(_f, _a...)           tlog_syslog(TLOG_WARN, "nbd: " _f, ##_a)
+#define ERR(_f, _a...)             tlog_syslog(TLOG_WARN, "nbd: " _f, ##_a)
+#define BUG() do {						\
+		ERR("Aborting");				\
+		abort();					\
+	} while (0)
+#define BUG_ON(_cond)						\
+	if (unlikely(_cond)) {					\
+		ERR("(%s) = %d", #_cond, _cond);		\
+		BUG();						\
+	}
 
 struct td_nbdserver_req {
 	td_vbd_request_t        vreq;
@@ -59,14 +68,12 @@ struct td_nbdserver_req {
 	struct td_iovec         iov;
 };
 
-static void tapdisk_nbdserver_disable_client(td_nbdserver_client_t *client);
-int tapdisk_nbdserver_setup_listening_socket(td_nbdserver_t *server);
-int tapdisk_nbdserver_unpause(td_nbdserver_t *server);
-
 td_nbdserver_req_t *
 tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 {
 	td_nbdserver_req_t *req = NULL;
+
+	ASSERT(client);
 
 	if (likely(client->n_reqs_free))
 		req = client->reqs_free[--client->n_reqs_free];
@@ -78,11 +85,10 @@ void
 tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
 		td_nbdserver_req_t *req)
 {
-	if (client->n_reqs_free >= client->n_reqs) {
-		ERROR("Error, trying to free a client, but the free list "
-				"is full! leaking!");
-		return;
-	}
+	ASSERT(client);
+	ASSERT(req);
+	BUG_ON(client->n_reqs_free >= client->n_reqs);
+
 	client->reqs_free[client->n_reqs_free++] = req;
 
 	if (unlikely(client->dead && !tapdisk_nbdserver_reqs_pending(client)))
@@ -113,6 +119,9 @@ tapdisk_nbdserver_reqs_init(td_nbdserver_client_t *client, int n_reqs)
 {
 	int i, err;
 
+	ASSERT(client);
+	ASSERT(n_reqs > 0);
+
 	INFO("Reqs init");
 
 	client->reqs = malloc(n_reqs * sizeof(td_nbdserver_req_t));
@@ -120,6 +129,7 @@ tapdisk_nbdserver_reqs_init(td_nbdserver_client_t *client, int n_reqs)
 		err = -errno;
 		goto fail;
 	}
+
 	client->iovecs = malloc(n_reqs * sizeof(struct td_iovec));
 	if (!client->iovecs) {
 		err = - errno;
@@ -147,26 +157,62 @@ fail:
 	return err;
 }
 
+static int
+tapdisk_nbdserver_enable_client(td_nbdserver_client_t *client)
+{
+	ASSERT(client);
+	ASSERT(client->client_event_id == -1);
+	ASSERT(client->client_fd >= 0);
+
+	INFO("Enable client");
+
+	client->client_event_id = tapdisk_server_register_event(
+			SCHEDULER_POLL_READ_FD,
+			client->client_fd, 0,
+			tapdisk_nbdserver_clientcb,
+			client);
+
+	if (client->client_event_id < 0) {
+		ERR("Error registering events on client: %d",
+				client->client_event_id);
+		return client->client_event_id;
+	}
+
+	return client->client_event_id;
+}
+
+static void
+tapdisk_nbdserver_disable_client(td_nbdserver_client_t *client)
+{
+	ASSERT(client);
+	ASSERT(client->client_event_id >= 0);
+
+	INFO("Disable client");
+
+	tapdisk_server_unregister_event(client->client_event_id);
+	client->client_event_id = -1;
+}
+
 td_nbdserver_client_t *
 tapdisk_nbdserver_alloc_client(td_nbdserver_t *server)
 {
 	td_nbdserver_client_t *client = NULL;
 	int err;
 
+	ASSERT(server);
+
 	INFO("Alloc client");
 
-	client = malloc(sizeof(td_nbdserver_client_t));
+	client = calloc(1, sizeof(td_nbdserver_client_t));
 	if (!client) {
-		ERROR("Couldn't allocate client structure: %s",
+		ERR("Couldn't allocate client structure: %s",
 				strerror(errno));
 		goto fail;
 	}
 
-	bzero(client, sizeof(td_nbdserver_client_t));
-
 	err = tapdisk_nbdserver_reqs_init(client, NBD_SERVER_NUM_REQS);
 	if (err < 0) {
-		ERROR("Couldn't allocate client reqs: %d", err);
+		ERR("Couldn't allocate client reqs: %d", err);
 		goto fail;
 	}
 
@@ -182,12 +228,10 @@ tapdisk_nbdserver_alloc_client(td_nbdserver_t *server)
 	return client;
 
 fail:
-	if (client) {
+	if (client)
 		free(client);
-		client = NULL;
-	}
 
-	return client;
+	return NULL;
 }
 
 void
@@ -195,10 +239,7 @@ tapdisk_nbdserver_free_client(td_nbdserver_client_t *client)
 {
 	INFO("Free client");
 
-	if (!client) {
-		ERROR("Attempt to free NULL pointer!");
-		return;
-	}
+	ASSERT(client);
 
 	if (client->client_event_id >= 0)
 		tapdisk_nbdserver_disable_client(client);
@@ -209,50 +250,6 @@ tapdisk_nbdserver_free_client(td_nbdserver_client_t *client)
 		free(client);
 	} else
 		client->dead = true;
-}
-
-static int
-tapdisk_nbdserver_enable_client(td_nbdserver_client_t *client)
-{
-	INFO("Enable client");
-
-	if (client->client_event_id >= 0) {
-		ERROR("Attempting to enable an already-enabled client");
-		return -1;
-	}
-
-	if (client->client_fd < 0) {
-		ERROR("Attempting to register events on a closed client");
-		return -1;
-	}
-
-	client->client_event_id = tapdisk_server_register_event(
-			SCHEDULER_POLL_READ_FD,
-			client->client_fd, 0,
-			tapdisk_nbdserver_clientcb,
-			client);
-
-	if (client->client_event_id < 0) {
-		ERROR("Error registering events on client: %d",
-				client->client_event_id);
-		return client->client_event_id;
-	}
-
-	return client->client_event_id;
-}
-
-static void
-tapdisk_nbdserver_disable_client(td_nbdserver_client_t *client)
-{
-	INFO("Disable client");
-
-	if (client->client_event_id < 0) {
-		ERROR("Attempting to disable an already-disabled client");
-		return;
-	}
-
-	tapdisk_server_unregister_event(client->client_event_id);
-	client->client_event_id = -1;
 }
 
 static void
@@ -280,7 +277,7 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 	memcpy(reply.handle, req->id, sizeof(reply.handle));
 
 	if (client->client_fd < 0) {
-		ERROR("Finishing request for client that has disappeared");
+		ERR("Finishing request for client that has disappeared");
 		goto finish;
 	}
 
@@ -295,7 +292,7 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 					tosend, 0);
 			if (sent <= 0) {
 				sent = errno;
-				ERROR("Short send/error in callback: %s", strerror(sent));
+				ERR("Short send/error in callback: %s", strerror(sent));
 				goto finish;
 			}
 
@@ -311,7 +308,56 @@ finish:
 	tapdisk_nbdserver_free_request(client, req);
 }
 
-static void tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd);
+static void
+tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
+{
+	td_nbdserver_client_t *client;
+	char buffer[256];
+	int rc;
+	uint64_t tmp64;
+	uint32_t tmp32;
+
+	ASSERT(server);
+	ASSERT(new_fd >= 0);
+
+	INFO("Got a new client!");
+
+	/* Spit out the NBD connection stuff */
+
+	memcpy(buffer, "NBDMAGIC", 8);
+	tmp64 = htonll(NBD_NEGOTIATION_MAGIC);
+	memcpy(buffer + 8, &tmp64, sizeof(tmp64));
+	tmp64 = htonll(server->info.size * server->info.sector_size);
+	memcpy(buffer + 16, &tmp64, sizeof(tmp64));
+	tmp32 = htonl(0);
+	memcpy(buffer + 24, &tmp32, sizeof(tmp32));
+	bzero(buffer + 28, 124);
+
+	rc = send(new_fd, buffer, 152, 0);
+
+	if (rc != 152) {
+		int err = errno;
+		close(new_fd);
+		if (rc == -1)
+			INFO("Short write in negotiation: %s", strerror(err));
+		else
+			INFO("Short write in negotiation: wrote %d bytes instead of 152\n",
+					rc);
+	}
+
+	INFO("About to alloc client");
+	client = tapdisk_nbdserver_alloc_client(server);
+
+	INFO("Got an allocated client at %p", client);
+	client->client_fd = new_fd;
+
+	INFO("About to enable client");
+	if (tapdisk_nbdserver_enable_client(client) < 0) {
+		ERR("Error enabling client");
+		tapdisk_nbdserver_free_client(client);
+		close(new_fd);
+	}
+}
 
 void
 tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
@@ -326,11 +372,11 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	char *ptr;
 	td_vbd_request_t *vreq;
 	struct nbd_request request;
+	td_nbdserver_req_t *req;
 
-	td_nbdserver_req_t *req = tapdisk_nbdserver_alloc_request(client);
-
-	if (req == NULL) {
-		ERROR("Couldn't allocate request in clientcb - killing client");
+	req = tapdisk_nbdserver_alloc_request(client);
+	if (!req) {
+		ERR("Couldn't allocate request in clientcb - killing client");
 		tapdisk_nbdserver_free_client(client);
 		return;
 	}
@@ -345,6 +391,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	n = 0;
 	ptr = (char *) &request;
 	while (n < hdrlen) {
+		// FIXME: need to select() on fd with a sensible timeout
 		rc = recv(fd, ptr + n, hdrlen - n, 0);
 		if (rc == 0) {
 			INFO("Client closed connection");
@@ -352,7 +399,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 		}
 		if (rc < 0) {
 			rc = errno;
-			ERROR("failed to receive from client: %s. Closing connection",
+			ERR("failed to receive from client: %s. Closing connection",
 					strerror(rc));
 			goto fail;
 		}
@@ -360,7 +407,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	}
 
 	if (request.magic != htonl(NBD_REQUEST_MAGIC)) {
-		ERROR("Not enough magic");
+		ERR("Not enough magic");
 		goto fail;
 	}
 
@@ -368,7 +415,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	request.type = ntohl(request.type);
 	len = ntohl(request.len);
 	if (((len & 0x1ff) != 0) || ((request.from & 0x1ff) != 0)) {
-		ERROR("Non sector-aligned request (%"PRIu64", %d)",
+		ERR("Non sector-aligned request (%"PRIu64", %d)",
 				request.from, len);
 	}
 
@@ -377,7 +424,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 
 	rc = posix_memalign(&req->iov.base, 512, len);
 	if (rc < 0) {
-		ERROR("posix_memalign failed (%d)", rc);
+		ERR("posix_memalign failed (%d)", rc);
 		goto fail;
 	}
 
@@ -401,7 +448,7 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 		while (n < len) {
 			rc = recv(fd, vreq->iov->base + n, (len - n), 0);
 			if (rc <= 0) {
-				ERROR("Short send or error in "
+				ERR("Short send or error in "
 						"callback: %d", rc);
 				goto fail;
 			}
@@ -420,13 +467,13 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 		return;
 
 	default:
-		ERROR("Unsupported operation: 0x%x", request.type);
+		ERR("Unsupported operation: 0x%x", request.type);
 		goto fail;
 	}
 
 	rc = tapdisk_vbd_queue_request(server->vbd, vreq);
 	if (rc) {
-		ERROR("tapdisk_vbd_queue_request failed: %d", rc);
+		ERR("tapdisk_vbd_queue_request failed: %d", rc);
 		goto fail;
 	}
 
@@ -438,57 +485,16 @@ fail:
 }
 
 static void
-tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
-{
-	char buffer[256];
-	int rc;
-	uint64_t tmp64;
-	uint32_t tmp32;
-
-	INFO("Got a new client!");
-
-	/* Spit out the NBD connection stuff */
-
-	memcpy(buffer, "NBDMAGIC", 8);
-	tmp64 = htonll(NBD_NEGOTIATION_MAGIC);
-	memcpy(buffer + 8, &tmp64, sizeof(tmp64));
-	tmp64 = htonll(server->info.size * server->info.sector_size);
-	memcpy(buffer + 16, &tmp64, sizeof(tmp64));
-	tmp32 = htonl(0);
-	memcpy(buffer + 24, &tmp32, sizeof(tmp32));
-	bzero(buffer + 28, 124);
-
-	rc = send(new_fd, buffer, 152, 0);
-
-	if (rc < 152) {
-		int err = errno;
-		close(new_fd);
-		if (rc == -1)
-			INFO("Short write in negotiation: %s", strerror(err));
-		else
-			INFO("Short write in negotiation: wrote %d bytes instead of 152\n",
-					rc);
-	}
-
-	INFO("About to alloc client");
-	td_nbdserver_client_t *client = tapdisk_nbdserver_alloc_client(server);
-	INFO("Got an allocated client at %p", client);
-	client->client_fd = new_fd;
-	INFO("About to enable client");
-
-	if (tapdisk_nbdserver_enable_client(client) < 0) {
-		ERROR("Error enabling client");
-		tapdisk_nbdserver_free_client(client);
-		close(new_fd);
-		return;
-	}
-}
-
-static void
 tapdisk_nbdserver_fdreceiver_cb(int fd, char *msg, void *data)
 {
 	td_nbdserver_t *server = data;
+
+	ASSERT(server);
+	ASSERT(msg);
+	ASSERT(fd >= 0);
+
 	INFO("Received fd with msg: %s", msg);
+
 	tapdisk_nbdserver_newclient_fd(server, fd);
 }
 
@@ -497,26 +503,27 @@ tapdisk_nbdserver_newclient(event_id_t id, char mode, void *data)
 {
 	struct sockaddr_storage their_addr;
 	socklen_t sin_size = sizeof(their_addr);
-	char s[INET6_ADDRSTRLEN];
+	char s[INET6_ADDRSTRLEN+1];
 	int new_fd;
 	td_nbdserver_t *server = data;
 
+	ASSERT(server);
+
 	INFO("About to accept (server->fdrecv_listening_fd = %d)",
 			server->fdrecv_listening_fd);
+
 	new_fd = accept(server->fdrecv_listening_fd,
 			(struct sockaddr *)&their_addr, &sin_size);
 
 	if (new_fd == -1) {
-		ERROR("failed to accept connection on the fd receiver socket: %s",
+		ERR("failed to accept connection on the fd receiver socket: %s",
 				strerror(errno));
 		return;
 	}
 
-	inet_ntop(their_addr.ss_family, get_in_addr(&their_addr), s, sizeof s);
+	memset(s, 0, sizeof(s));
+	inet_ntop(their_addr.ss_family, get_in_addr(&their_addr), s, sizeof(s)-1);
 
-	/*
-	 * FIXME this prints garbage
-	 */
 	INFO("server: got connection from %s\n", s);
 
 	tapdisk_nbdserver_newclient_fd(server, new_fd);
@@ -532,9 +539,12 @@ tapdisk_nbdserver_newclient_unix(event_id_t id, char mode, void *data)
 
 	ASSERT(server);
 
+	INFO("About to accept (server->unix_listening_fd = %d)",
+			server->unix_listening_fd);
+
 	new_fd = accept(server->unix_listening_fd, (struct sockaddr *)&remote, &t);
 	if (new_fd == -1) {
-		ERROR("failed to accept connection: %s\n", strerror(errno));
+		ERR("failed to accept connection: %s\n", strerror(errno));
 		return;
 	}
 
@@ -548,187 +558,53 @@ tapdisk_nbdserver_alloc(td_vbd_t *vbd, td_disk_info_t info)
 {
 	td_nbdserver_t *server;
 	char fdreceiver_path[TAPDISK_NBDSERVER_MAX_PATH_LEN];
-	int err = 0;
 
-	server = malloc(sizeof(*server));
+	server = calloc(1, sizeof(*server));
 	if (!server) {
-		err = errno;
-		ERROR("Failed to allocate memory for nbdserver: %s", strerror(err));
-		goto out;
+		ERR("Failed to allocate memory for nbdserver: %s",
+				strerror(errno));
+		goto fail;
 	}
 
-	memset(server, 0, sizeof(*server));
+	server->vbd = vbd;
+	server->info = info;
 	server->fdrecv_listening_fd = -1;
 	server->fdrecv_listening_event_id = -1;
 	server->unix_listening_fd = -1;
 	server->unix_listening_event_id = -1;
 	INIT_LIST_HEAD(&server->clients);
 
-	server->vbd = vbd;
-	server->info = info;
-
-	snprintf(fdreceiver_path, TAPDISK_NBDSERVER_MAX_PATH_LEN, "%s%d.%d",
-			TAPDISK_NBDSERVER_LISTEN_SOCK_PATH, getpid(),
-			vbd->uuid);
+	if (snprintf(fdreceiver_path, TAPDISK_NBDSERVER_MAX_PATH_LEN,
+			"%s%d.%d", TAPDISK_NBDSERVER_LISTEN_SOCK_PATH, getpid(),
+			vbd->uuid) < 0) {
+		ERR("Failed to snprintf fdreceiver_path");
+		goto fail;
+	}
 
 	server->fdreceiver = td_fdreceiver_start(fdreceiver_path,
 			tapdisk_nbdserver_fdreceiver_cb, server);
-
 	if (!server->fdreceiver) {
-		ERROR("Error setting up fd receiver");
-		goto out;
+		ERR("Error setting up fd receiver");
+		goto fail;
 	}
 
-	if (-1 == snprintf(server->sockpath, TAPDISK_NBDSERVER_MAX_PATH_LEN,
-				"%s%d.%d", TAPDISK_NBDSERVER_SOCK_PATH, getpid(), vbd->uuid))
-	{
-		err = errno;
-		ERROR("failed to snprintf %s...%d: %s", TAPDISK_NBDSERVER_SOCK_PATH,
-				vbd->uuid, strerror(err));
-		goto out;
+	if (snprintf(server->sockpath, TAPDISK_NBDSERVER_MAX_PATH_LEN,
+			"%s%d.%d", TAPDISK_NBDSERVER_SOCK_PATH, getpid(),
+			vbd->uuid) < 0) {
+		ERR("Failed to snprintf sockpath");
+		goto fail;
 	}
 
-out:
-	if (err) {
-		if (server) {
-			tapdisk_server_unregister_event(server->fdrecv_listening_event_id);
-			close(server->fdrecv_listening_fd);
-			free(server);
-		}
-		return NULL;
-	} else
-		return server;
-}
+	return server;
 
-int
-tapdisk_nbdserver_listen_inet(td_nbdserver_t *server, const int port)
-{
-	struct addrinfo hints, *servinfo, *p;
-	char portstr[10];
-	int err;
-	int yes = 1;
-
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = AI_PASSIVE;
-
-	snprintf(portstr, 10, "%d", port);
-
-	if ((err = getaddrinfo(NULL, portstr, &hints, &servinfo)) != 0) {
-		ERROR("Failed to getaddrinfo");
-		return -1;
+fail:
+	if (server) {
+		if (server->fdreceiver)
+			td_fdreceiver_stop(server->fdreceiver);
+		free(server);
 	}
 
-	for (p = servinfo; p != NULL; p = p->ai_next) {
-		if ((server->fdrecv_listening_fd = socket(AF_INET, SOCK_STREAM, 0)) ==
-				-1) {
-			ERROR("Failed to create socket");
-			continue;
-		}
-
-		if (setsockopt(server->fdrecv_listening_fd, SOL_SOCKET, SO_REUSEADDR,
-					&yes, sizeof(int)) == -1) {
-			ERROR("Failed to setsockopt");
-			close(server->fdrecv_listening_fd);
-			return -1;
-		}
-
-		if (bind(server->fdrecv_listening_fd, p->ai_addr, p->ai_addrlen) ==
-				-1) {
-			ERROR("Failed to bind");
-			close(server->fdrecv_listening_fd);
-			continue;
-		}
-
-		break;
-	}
-
-	if (p == NULL) {
-		ERROR("Failed to bind");
-		close(server->fdrecv_listening_fd);
-		return -1;
-	}
-
-	freeaddrinfo(servinfo);
-
-	if (listen(server->fdrecv_listening_fd, 10) == -1) {
-		ERROR("listen");
-		return -1;
-	}
-
-	tapdisk_nbdserver_unpause(server);
-
-	if (server->fdrecv_listening_event_id < 0) {
-		err = server->fdrecv_listening_event_id;
-		close(server->fdrecv_listening_fd);
-		return -1;
-	}
-
-	INFO("Successfully started NBD server");
-
-	return 0;
-}
-
-int
-tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
-{
-	size_t len = 0;
-	int err = 0;
-
-	ASSERT(server);
-
-	ASSERT(server->unix_listening_fd == -1);
-
-	server->unix_listening_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (server->unix_listening_fd == -1) {
-		err = -errno;
-		ERROR("failed to create UNIX domain socket: %s\n", strerror(-err));
-		goto out;
-    }
-
-	server->local.sun_family = AF_UNIX;
-    strcpy(server->local.sun_path, server->sockpath);
-    err = unlink(server->local.sun_path);
-	if (err == -1 && errno != ENOENT) {
-		err = -errno;
-		ERROR("failed to remove %s: %s\n", server->local.sun_path,
-				strerror(-err));
-		goto out;
-	}
-    len = strlen(server->local.sun_path) + sizeof(server->local.sun_family);
-	err = bind(server->unix_listening_fd, (struct sockaddr *)&server->local,
-			len);
-    if (err == -1) {
-		err = -errno;
-		ERROR("failed to bind: %s\n", strerror(-err));
-		goto out;
-    }
-
-	err = listen(server->unix_listening_fd, 10);
-	if (err == -1) {
-		err = -errno;
-		ERROR("failed to listen: %s\n", strerror(-err));
-		goto out;
-	}
-
-	tapdisk_nbdserver_unpause(server);
-
-	if (server->unix_listening_event_id < 0) {
-		ERROR("failed to unpause the NBD server: %s\n",
-				strerror(-server->unix_listening_event_id));
-		err = server->unix_listening_event_id;
-		server->unix_listening_event_id = -1;
-		goto out;
-	}
-
-	INFO("Successfully started NBD server on %s\n", server->sockpath);
-
-out:
-	if (err)
-		if (server->unix_listening_fd != -1)
-			close(server->unix_listening_fd);
-	return err;
+	return NULL;
 }
 
 void
@@ -745,17 +621,215 @@ tapdisk_nbdserver_pause(td_nbdserver_t *server)
 		}
 	}
 
-	if (server->fdrecv_listening_event_id >= 0)
+	if (server->fdrecv_listening_event_id >= 0) {
 		tapdisk_server_unregister_event(server->fdrecv_listening_event_id);
+		server->fdrecv_listening_event_id = -1;
+	}
 
-	if (server->unix_listening_event_id >= 0)
+	if (server->unix_listening_event_id >= 0) {
 		tapdisk_server_unregister_event(server->unix_listening_event_id);
+		server->unix_listening_event_id = -1;
+	}
+}
+
+static int
+tapdisk_nbdserver_unpause_fdrecv(td_nbdserver_t *server)
+{
+	int err = 0;
+
+	ASSERT(server);
+
+	if (server->fdrecv_listening_event_id < 0
+			&& server->fdrecv_listening_fd >= 0) {
+		INFO("registering for fdrecv_listening_fd");
+		server->fdrecv_listening_event_id =
+			tapdisk_server_register_event(SCHEDULER_POLL_READ_FD,
+					server->fdrecv_listening_fd, 0,
+					tapdisk_nbdserver_newclient,
+					server);
+		if (server->fdrecv_listening_event_id < 0) {
+			err = server->fdrecv_listening_event_id;
+			server->fdrecv_listening_event_id = -1;
+		}
+	}
+
+	return err;
+}
+
+static int
+tapdisk_nbdserver_unpause_unix(td_nbdserver_t *server)
+{
+	int err = 0;
+
+	ASSERT(server);
+
+	if (server->unix_listening_event_id < 0
+			&& server->unix_listening_fd >= 0) {
+		INFO("registering for unix_listening_fd");
+		server->unix_listening_event_id =
+			tapdisk_server_register_event(SCHEDULER_POLL_READ_FD,
+					server->unix_listening_fd, 0,
+					tapdisk_nbdserver_newclient_unix,
+					server);
+		if (server->unix_listening_event_id < 0) {
+			err = server->unix_listening_event_id;
+			server->unix_listening_event_id = -1;
+		}
+	}
+
+	return err;
+}
+
+int
+tapdisk_nbdserver_listen_inet(td_nbdserver_t *server, const int port)
+{
+	struct addrinfo hints, *servinfo, *p;
+	char portstr[10];
+	int err;
+	int yes = 1;
+
+	ASSERT(server);
+	ASSERT(server->fdrecv_listening_fd == -1);
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_PASSIVE;
+
+	snprintf(portstr, 10, "%d", port);
+
+	err = getaddrinfo(NULL, portstr, &hints, &servinfo);
+	if (err) {
+		if (err == EAI_SYSTEM) {
+			ERR("Failed to getaddrinfo: %s", strerror(errno));
+			return -errno;
+		} else {
+			ERR("Failed to getaddrinfo: %s", gai_strerror(err));
+			return -1;
+		}
+	}
+
+	for (p = servinfo; p != NULL; p = p->ai_next) {
+		if ((server->fdrecv_listening_fd = socket(AF_INET, SOCK_STREAM, 0)) ==
+				-1) {
+			ERR("Failed to create socket");
+			continue;
+		}
+
+		if (setsockopt(server->fdrecv_listening_fd, SOL_SOCKET, SO_REUSEADDR,
+					&yes, sizeof(int)) == -1) {
+			ERR("Failed to setsockopt");
+			close(server->fdrecv_listening_fd);
+			continue;
+		}
+
+		if (bind(server->fdrecv_listening_fd, p->ai_addr, p->ai_addrlen) ==
+				-1) {
+			ERR("Failed to bind");
+			close(server->fdrecv_listening_fd);
+			continue;
+		}
+
+		break;
+	}
+
+	freeaddrinfo(servinfo);
+
+	if (p == NULL) {
+		ERR("Failed to bind");
+		err = -1;
+		goto out;
+	}
+
+	err = listen(server->fdrecv_listening_fd, 10);
+	if (err) {
+		err = -errno;
+		ERR("listen: %s", strerror(-err));
+		goto out;
+	}
+
+	err = tapdisk_nbdserver_unpause_fdrecv(server);
+	if (err) {
+		ERR("failed to unpause the NBD server (fdrecv): %s\n",
+				strerror(-err));
+		goto out;
+	}
+
+	INFO("Successfully started NBD server (fdrecv)");
+
+out:
+	if (err && (server->fdrecv_listening_fd != -1)) {
+		close(server->fdrecv_listening_fd);
+		server->fdrecv_listening_fd = -1;
+	}
+	return err;
+}
+
+int
+tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
+{
+	size_t len = 0;
+	int err = 0;
+
+	ASSERT(server);
+	ASSERT(server->unix_listening_fd == -1);
+
+	server->unix_listening_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (server->unix_listening_fd == -1) {
+		err = -errno;
+		ERR("failed to create UNIX domain socket: %s\n", strerror(-err));
+		goto out;
+	}
+
+	server->local.sun_family = AF_UNIX;
+	strcpy(server->local.sun_path, server->sockpath);
+	err = unlink(server->local.sun_path);
+	if (err == -1 && errno != ENOENT) {
+		err = -errno;
+		ERR("failed to remove %s: %s\n", server->local.sun_path,
+				strerror(-err));
+		goto out;
+	}
+	len = strlen(server->local.sun_path) + sizeof(server->local.sun_family);
+	err = bind(server->unix_listening_fd, (struct sockaddr *)&server->local,
+			len);
+	if (err == -1) {
+		err = -errno;
+		ERR("failed to bind: %s\n", strerror(-err));
+		goto out;
+	}
+
+	err = listen(server->unix_listening_fd, 10);
+	if (err == -1) {
+		err = -errno;
+		ERR("failed to listen: %s\n", strerror(-err));
+		goto out;
+	}
+
+	err = tapdisk_nbdserver_unpause_unix(server);
+	if (err) {
+		ERR("failed to unpause the NBD server (unix): %s\n",
+				strerror(-err));
+		goto out;
+	}
+
+	INFO("Successfully started NBD server on %s\n", server->sockpath);
+
+out:
+	if (err && (server->unix_listening_fd != -1)) {
+		close(server->unix_listening_fd);
+		server->unix_listening_fd = -1;
+	}
+	return err;
 }
 
 int
 tapdisk_nbdserver_unpause(td_nbdserver_t *server)
 {
 	struct td_nbdserver_client *pos, *q;
+	int err;
+
+	ASSERT(server);
 
 	INFO("NBD server unpause(%p) - fdrecv_listening_fd %d, "
 			"unix_listening_fd=%d", server,	server->fdrecv_listening_fd,
@@ -768,33 +842,15 @@ tapdisk_nbdserver_unpause(td_nbdserver_t *server)
 		}
 	}
 
-	if (server->fdrecv_listening_event_id < 0
-			&& server->fdrecv_listening_fd >= 0) {
-		server->fdrecv_listening_event_id =
-			tapdisk_server_register_event(SCHEDULER_POLL_READ_FD,
-					server->fdrecv_listening_fd, 0,
-					tapdisk_nbdserver_newclient,
-					server);
-		INFO("registering for fdrecv_listening_fd");
-		if (server->fdrecv_listening_event_id < 0)
-			return server->fdrecv_listening_event_id;
-	}
+	err = tapdisk_nbdserver_unpause_fdrecv(server);
+	if (err)
+		return err;
 
-	if (server->unix_listening_event_id < 0
-			&& server->unix_listening_fd >= 0) {
-		server->unix_listening_event_id =
-			tapdisk_server_register_event(SCHEDULER_POLL_READ_FD,
-					server->unix_listening_fd, 0,
-					tapdisk_nbdserver_newclient_unix,
-					server);
-		INFO("registering for unix_listening_fd");
-		if (server->unix_listening_event_id < 0) {
-			tapdisk_server_unregister_event(server->fdrecv_listening_event_id);
-			return server->fdrecv_listening_event_id;
-		}
-	}
+	err = tapdisk_nbdserver_unpause_unix(server);
+	if (err)
+		return err;
 
-	return server->fdrecv_listening_event_id;
+	return 0;
 }
 
 void
@@ -821,17 +877,27 @@ tapdisk_nbdserver_free(td_nbdserver_t *server)
 	if (server->fdreceiver)
 		td_fdreceiver_stop(server->fdreceiver);
 
+	if (server->unix_listening_event_id >= 0) {
+		tapdisk_server_unregister_event(server->unix_listening_event_id);
+		server->unix_listening_event_id = -1;
+	}
+
+	if (server->unix_listening_fd >= 0) {
+		close(server->unix_listening_fd);
+		server->unix_listening_fd = -1;
+	}
+
 	err = unlink(server->sockpath);
 	if (err)
-		ERROR("failed to remove UNIX domain socket %s: %s\n", server->sockpath,
+		ERR("failed to remove UNIX domain socket %s: %s\n", server->sockpath,
 				strerror(errno));
 
 	free(server);
 }
 
 int
-tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client) {
-
+tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client)
+{
 	ASSERT(client);
 
 	return client->n_reqs - client->n_reqs_free;
@@ -839,8 +905,8 @@ tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client) {
 
 bool
 tapdisk_nbdserver_contains_client(td_nbdserver_t *server,
-		td_nbdserver_client_t *client) {
-
+		td_nbdserver_client_t *client)
+{
 	td_nbdserver_client_t *_client;
 
 	ASSERT(server);

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -58,7 +58,7 @@ struct td_nbdserver {
 	/**
 	 * Socket for the UNIX domain socket.
 	 */
-	struct sockaddr_un		local;
+	struct sockaddr_un	local;
 
 	/**
 	 * UNIX domain socket path.


### PR DESCRIPTION
There are several issues with the nbdserver code in tapdisk3. It leaks
the unix listening fd when tapdisk closes an image. The pause/unpause
code also has issues. Other refactoring would make the code more
resilient and readable.

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>