### PR TITLE
CA-161449: Stats between tapdisk and vdi traffic

### DIFF
--- a/drivers/tapdisk-blktap.h
+++ b/drivers/tapdisk-blktap.h
@@ -24,6 +24,7 @@ typedef struct td_blktap_req td_blktap_req_t;
 #include "blktap.h"
 #include "tapdisk-vbd.h"
 #include "list.h"
+#include "tapdisk-metrics.h"
 
 struct td_blktap_stats {
 	struct {
@@ -60,6 +61,8 @@ struct td_blktap {
 	struct list_head        entry;
 
 	struct td_blktap_stats  stats;
+
+        stats_t blktap_stats;
 };
 
 int tapdisk_blktap_open(const char *, td_vbd_t *, td_blktap_t **);

--- a/drivers/tapdisk-metrics.c
+++ b/drivers/tapdisk-metrics.c
@@ -241,3 +241,58 @@ td_metrics_vbd_stop(stats_t *vbd_stats)
 end:
     return err;
 }
+
+int
+td_metrics_blktap_start(int minor, stats_t *blktap_stats)
+{
+
+    int err = 0;
+
+    if(!td_metrics.path)
+        goto out;
+
+    shm_init(&blktap_stats->shm);
+
+    err = asprintf(&blktap_stats->shm.path, TAPDISK_METRICS_BLKTAP_PATHF, td_metrics.path, minor);
+    if(unlikely(err == -1)){
+        err = errno;
+        EPRINTF("failed to allocate memory to store blktap metrics path: %s\n",strerror(err));
+        blktap_stats->shm.path = NULL;
+        goto out;
+    }
+
+    blktap_stats->shm.size = PAGE_SIZE;
+
+    err = shm_create(&blktap_stats->shm);
+    if (unlikely(err)) {
+        err = errno;
+        EPRINTF("failed to create blktap shm ring stats file: %s\n", strerror(err));
+        goto out;
+    }
+    blktap_stats->stats = blktap_stats->shm.mem;
+out:
+    return err;
+}
+
+int
+td_metrics_blktap_stop(stats_t *blktap_stats)
+{
+    int err = 0;
+
+    if(!blktap_stats->shm.path)
+        goto end;
+
+    err = shm_destroy(&blktap_stats->shm);
+    if (unlikely(err)) {
+        err = errno;
+        EPRINTF("failed to destroy blktap metrics file: %s\n", strerror(err));
+    }
+
+    free(blktap_stats->shm.path);
+    blktap_stats->shm.path = NULL;
+
+end:
+    return err;
+
+}
+

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -21,6 +21,7 @@
 
 #define TAPDISK_METRICS_PATHF     "/dev/shm/td3-%d"
 #define TAPDISK_METRICS_VDI_PATHF "%s/vdi-%hu"
+#define TAPDISK_METRICS_VBD_PATHF "%s/vbd-%d-%d"
 
 #include <libaio.h>
 
@@ -51,8 +52,17 @@ typedef struct {
 int td_metrics_start();
 /* Destroys the folder /dev/shm/td3-<pid> and its contents */
 void td_metrics_stop();
-/* Creates the shm for the file that will store the metrics */
+
+/* Creates the shm for the file that stores metrics from tapdisk to the vdi */
 int td_metrics_vdi_start(int minor, stats_t *vdi_stats);
-/* Destroys the files created to store metrics */
+
+/* Destroys the files created to store the metrics from tapdisk to the vdi */
 int td_metrics_vdi_stop(stats_t *vdi_stats);
+
+/* Creates the metrics file to store the stats from blkfront to tapdisk */
+int td_metrics_vbd_start(int domain, int id, stats_t *vbd_stats);
+
+/* Destroys the files created to store metrics from blkfront to tapdisk */
+int td_metrics_vbd_stop(stats_t *vbd_stats);
+
 #endif /* TAPDISK_METRICS_H */

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -23,6 +23,7 @@
 #define TAPDISK_METRICS_VDI_PATHF    "%s/vdi-%hu"
 #define TAPDISK_METRICS_VBD_PATHF    "%s/vbd-%d-%d"
 #define TAPDISK_METRICS_BLKTAP_PATHF "%s/blktap-%d"
+#define TAPDISK_METRICS_NBD_PATHF "%s/nbd-%d"
 
 #include <libaio.h>
 
@@ -72,4 +73,7 @@ int td_metrics_blktap_start(int minor, stats_t *blktap_stats);
 /* Destroys the metrics file between tapdisk and blktap */
 int td_metrics_blktap_stop(stats_t *blktap_stats);
 
+int td_metrics_nbd_start(stats_t *nbd_server, int minor);
+
+int td_metrics_nbd_stop(stats_t *nbd_server);
 #endif /* TAPDISK_METRICS_H */

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -19,7 +19,29 @@
 #ifndef TAPDISK_METRICS_H
 #define TAPDISK_METRICS_H
 
-#define TAPDISK_METRICS_PATHF "/dev/shm/td3-%d"
+#define TAPDISK_METRICS_PATHF     "/dev/shm/td3-%d"
+#define TAPDISK_METRICS_VDI_PATHF "%s/vdi-%hu"
+
+#include <libaio.h>
+
+#include "tapdisk-utils.h"
+#include "tapdisk.h"
+
+struct stats {
+    unsigned long long read_reqs_submitted;
+    unsigned long long read_reqs_completed;
+    unsigned long long read_sectors;
+    unsigned long long read_total_ticks;
+    unsigned long long write_reqs_submitted;
+    unsigned long long write_reqs_completed;
+    unsigned long long write_sectors;
+    unsigned long long write_total_ticks;
+};
+
+typedef struct {
+    struct shm shm;
+    struct stats *stats;
+} stats_t;
 
 typedef struct {
     char *path;
@@ -27,8 +49,10 @@ typedef struct {
 
 /* Creates a folder in which to store tapdisk3 statistics: /dev/shm/td3-<pid> */
 int td_metrics_start();
-
 /* Destroys the folder /dev/shm/td3-<pid> and its contents */
 void td_metrics_stop();
-
+/* Creates the shm for the file that will store the metrics */
+int td_metrics_vdi_start(int minor, stats_t *vdi_stats);
+/* Destroys the files created to store metrics */
+int td_metrics_vdi_stop(stats_t *vdi_stats);
 #endif /* TAPDISK_METRICS_H */

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -19,9 +19,10 @@
 #ifndef TAPDISK_METRICS_H
 #define TAPDISK_METRICS_H
 
-#define TAPDISK_METRICS_PATHF     "/dev/shm/td3-%d"
-#define TAPDISK_METRICS_VDI_PATHF "%s/vdi-%hu"
-#define TAPDISK_METRICS_VBD_PATHF "%s/vbd-%d-%d"
+#define TAPDISK_METRICS_PATHF        "/dev/shm/td3-%d"
+#define TAPDISK_METRICS_VDI_PATHF    "%s/vdi-%hu"
+#define TAPDISK_METRICS_VBD_PATHF    "%s/vbd-%d-%d"
+#define TAPDISK_METRICS_BLKTAP_PATHF "%s/blktap-%d"
 
 #include <libaio.h>
 
@@ -64,5 +65,11 @@ int td_metrics_vbd_start(int domain, int id, stats_t *vbd_stats);
 
 /* Destroys the files created to store metrics from blkfront to tapdisk */
 int td_metrics_vbd_stop(stats_t *vbd_stats);
+
+/* Creates the metrics file between tapdisk and blktap */
+int td_metrics_blktap_start(int minor, stats_t *blktap_stats);
+
+/* Destroys the metrics file between tapdisk and blktap */
+int td_metrics_blktap_stop(stats_t *blktap_stats);
 
 #endif /* TAPDISK_METRICS_H */

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -269,7 +269,10 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 		void *token, int final)
 {
 	td_nbdserver_client_t *client = token;
+        td_nbdserver_t *server = client->server;
 	td_nbdserver_req_t *req = containerof(vreq, td_nbdserver_req_t, vreq);
+        unsigned long long interval;
+        struct timeval now;
 	struct nbd_reply reply;
 	int tosend = 0;
 	int sent = 0;
@@ -278,6 +281,9 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 	reply.magic = htonl(NBD_REPLY_MAGIC);
 	reply.error = htonl(error);
 	memcpy(reply.handle, req->id, sizeof(reply.handle));
+
+        gettimeofday(&now, NULL);
+        interval = timeval_to_us(&now) - timeval_to_us(&vreq->ts);
 
 	if (client->client_fd < 0) {
 		ERROR("Finishing request for client that has disappeared");
@@ -289,6 +295,9 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 	switch(vreq->op) {
 	case TD_OP_READ:
 		tosend = len = vreq->iov->secs << SECTOR_SHIFT;
+                server->nbd_stats.stats->read_reqs_completed++;
+                server->nbd_stats.stats->read_sectors += vreq->iov->secs;
+                server->nbd_stats.stats->read_total_ticks += interval;
 		while (tosend > 0) {
 			sent = send(client->client_fd,
 					vreq->iov->base + (len - tosend),
@@ -302,6 +311,10 @@ __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 			tosend -= sent;
 		}
 		break;
+        case TD_OP_WRITE:
+                server->nbd_stats.stats->write_reqs_completed++;
+                server->nbd_stats.stats->write_sectors += vreq->iov->secs;
+                server->nbd_stats.stats->write_total_ticks += interval;
 	default:
 		break;
 	}
@@ -393,10 +406,11 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	switch(request.type) {
 	case NBD_CMD_READ:
 		vreq->op = TD_OP_READ;
+                server->nbd_stats.stats->read_reqs_submitted++;
 		break;
 	case NBD_CMD_WRITE:
 		vreq->op = TD_OP_WRITE;
-
+                server->nbd_stats.stats->write_reqs_submitted++;
 		n = 0;
 		while (n < len) {
 			rc = recv(fd, vreq->iov->base + n, (len - n), 0);
@@ -548,56 +562,60 @@ tapdisk_nbdserver_alloc(td_vbd_t *vbd, td_disk_info_t info)
 {
 	td_nbdserver_t *server;
 	char fdreceiver_path[TAPDISK_NBDSERVER_MAX_PATH_LEN];
-	int err = 0;
 
-	server = malloc(sizeof(*server));
+	server = calloc(1, sizeof(*server));
 	if (!server) {
-		err = errno;
-		ERROR("Failed to allocate memory for nbdserver: %s", strerror(err));
-		goto out;
+		ERR("Failed to allocate memory for nbdserver: %s",
+				strerror(errno));
+		goto fail;
 	}
 
-	memset(server, 0, sizeof(*server));
+	server->vbd = vbd;
+	server->info = info;
 	server->fdrecv_listening_fd = -1;
 	server->fdrecv_listening_event_id = -1;
 	server->unix_listening_fd = -1;
 	server->unix_listening_event_id = -1;
 	INIT_LIST_HEAD(&server->clients);
 
-	server->vbd = vbd;
-	server->info = info;
+        err = td_metrics_nbd_start(&server->nbd_stats, server->vbd->tap->minor);
 
-	snprintf(fdreceiver_path, TAPDISK_NBDSERVER_MAX_PATH_LEN, "%s%d.%d",
-			TAPDISK_NBDSERVER_LISTEN_SOCK_PATH, getpid(),
-			vbd->uuid);
+        if(err){
+            err = errno;
+            ERR("failed to create metrics file for nbdserver: %s", strerror(err));
+        }
+
+	if (snprintf(fdreceiver_path, TAPDISK_NBDSERVER_MAX_PATH_LEN,
+			"%s%d.%d", TAPDISK_NBDSERVER_LISTEN_SOCK_PATH, getpid(),
+			vbd->uuid) < 0) {
+		ERR("Failed to snprintf fdreceiver_path");
+		goto fail;
+	}
 
 	server->fdreceiver = td_fdreceiver_start(fdreceiver_path,
 			tapdisk_nbdserver_fdreceiver_cb, server);
-
 	if (!server->fdreceiver) {
-		ERROR("Error setting up fd receiver");
-		goto out;
+		ERR("Error setting up fd receiver");
+		goto fail;
 	}
 
-	if (-1 == snprintf(server->sockpath, TAPDISK_NBDSERVER_MAX_PATH_LEN,
-				"%s%d.%d", TAPDISK_NBDSERVER_SOCK_PATH, getpid(), vbd->uuid))
-	{
-		err = errno;
-		ERROR("failed to snprintf %s...%d: %s", TAPDISK_NBDSERVER_SOCK_PATH,
-				vbd->uuid, strerror(err));
-		goto out;
+	if (snprintf(server->sockpath, TAPDISK_NBDSERVER_MAX_PATH_LEN,
+			"%s%d.%d", TAPDISK_NBDSERVER_SOCK_PATH, getpid(),
+			vbd->uuid) < 0) {
+		ERR("Failed to snprintf sockpath");
+		goto fail;
 	}
 
-out:
-	if (err) {
-		if (server) {
-			tapdisk_server_unregister_event(server->fdrecv_listening_event_id);
-			close(server->fdrecv_listening_fd);
-			free(server);
-		}
-		return NULL;
-	} else
-		return server;
+	return server;
+
+fail:
+	if (server) {
+		if (server->fdreceiver)
+			td_fdreceiver_stop(server->fdreceiver);
+		free(server);
+	}
+
+	return NULL;
 }
 
 int
@@ -825,6 +843,10 @@ tapdisk_nbdserver_free(td_nbdserver_t *server)
 	if (err)
 		ERROR("failed to remove UNIX domain socket %s: %s\n", server->sockpath,
 				strerror(errno));
+        err = td_metrics_nbd_stop(&server->nbd_stats);
+
+        if (err)
+            ERR("failed to delete NBD metrics: %s\n", strerror(errno));
 
 	free(server);
 }

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -66,6 +66,8 @@ struct td_nbdserver {
 	char                    sockpath[TAPDISK_NBDSERVER_MAX_PATH_LEN];
 
 	struct list_head        clients;
+
+        stats_t                 nbd_stats;
 };
 
 struct td_nbdserver_client {

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -38,6 +38,7 @@
 #include "tapdisk-driver.h"
 #include "tapdisk-server.h"
 #include "tapdisk-vbd.h"
+#include "tapdisk-metrics.h"
 #include "tapdisk-disktype.h"
 #include "tapdisk-interface.h"
 #include "tapdisk-stats.h"
@@ -236,6 +237,11 @@ tapdisk_vbd_close_vdi(td_vbd_t *vbd)
     if (err) {
         EPRINTF("failed to destroy RRD stats file: %s (error ignored)\n",
                 strerror(-err));
+    }
+
+    err = td_metrics_vdi_stop(&vbd->vdi_stats);
+    if (err) {
+        EPRINTF("failed to destroy stats file: %s\n", strerror(-err));
     }
 
 	tapdisk_image_close_chain(&vbd->images);
@@ -605,6 +611,9 @@ tapdisk_vbd_open_vdi(td_vbd_t *vbd, const char *name, td_flag_t flags, int prt_d
     if (err)
         goto fail;
 
+    err = td_metrics_vdi_start(vbd->tap->minor, &vbd->vdi_stats);
+    if (err)
+        goto fail;
 	if (tmp != vbd->name)
 		free(tmp);
 
@@ -1249,6 +1258,8 @@ __tapdisk_vbd_complete_td_request(td_vbd_t *vbd, td_vbd_request_t *vreq,
 	td_image_t *image = treq.image;
 	int err;
 
+        long long interval;
+
 	err = (res <= 0 ? res : -res);
 	vbd->secs_pending  -= treq.secs;
 	vreq->secs_pending -= treq.secs;
@@ -1276,6 +1287,18 @@ __tapdisk_vbd_complete_td_request(td_vbd_t *vbd, td_vbd_request_t *vreq,
 		}
 		vreq->error = (vreq->error ? : err);
 	}
+
+        interval = timeval_to_us(&vbd->ts) - timeval_to_us(&vreq->ts);
+
+        if(treq.op == TD_OP_READ){
+            vbd->vdi_stats.stats->read_reqs_completed++;
+            vbd->vdi_stats.stats->read_sectors += treq.secs;
+            vbd->vdi_stats.stats->read_total_ticks += interval;
+        }else{
+            vbd->vdi_stats.stats->write_reqs_completed++;
+            vbd->vdi_stats.stats->write_sectors += treq.secs;
+            vbd->vdi_stats.stats->write_total_ticks += interval;
+        }
 
 	tapdisk_vbd_complete_vbd_request(vbd, vreq);
 }
@@ -1475,6 +1498,7 @@ tapdisk_vbd_issue_request(td_vbd_t *vbd, td_vbd_request_t *vreq)
 		switch (vreq->op) {
 		case TD_OP_WRITE:
 			treq.op = TD_OP_WRITE;
+                        vbd->vdi_stats.stats->write_reqs_submitted++;
 			/*
 			 * it's important to queue the mirror request before 
 			 * queuing the main one. If the main image runs into 
@@ -1491,6 +1515,7 @@ tapdisk_vbd_issue_request(td_vbd_t *vbd, td_vbd_request_t *vreq)
 
 		case TD_OP_READ:
 			treq.op = TD_OP_READ;
+                        vbd->vdi_stats.stats->read_reqs_submitted++;
 			td_queue_read(treq.image, treq);
 			break;
 		}

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -25,7 +25,6 @@
 #include "tapdisk-image.h"
 #include "tapdisk-blktap.h"
 #include "td-blkif.h"
-#include "tapdisk-metrics.h"
 
 #define TD_VBD_REQUEST_TIMEOUT      120
 #define TD_VBD_MAX_RETRIES          100

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -25,6 +25,7 @@
 #include "tapdisk-image.h"
 #include "tapdisk-blktap.h"
 #include "td-blkif.h"
+#include "tapdisk-metrics.h"
 
 #define TD_VBD_REQUEST_TIMEOUT      120
 #define TD_VBD_MAX_RETRIES          100
@@ -146,6 +147,7 @@ struct td_vbd_handle {
 	td_disk_info_t              disk_info;
 
     struct td_vbd_rrd           rrd;
+    stats_t vdi_stats;
 };
 
 #define tapdisk_vbd_for_each_request(vreq, tmp, list)	                \

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -33,6 +33,7 @@
 #include "td-stats.h"
 #include "tapdisk-vbd.h"
 #include "tapdisk-utils.h"
+#include "tapdisk-metrics.h"
 
 struct td_xenio_ctx;
 struct td_vbd_handle;
@@ -124,6 +125,8 @@ struct td_xenblkif {
      * stats
      */
     struct td_xenblkif_stats stats;
+
+    stats_t vbd_stats;
 
     struct {
         /**

--- a/drivers/td-req.h
+++ b/drivers/td-req.h
@@ -61,6 +61,8 @@ struct td_xenblkif_req {
      */
     char name[16 + 1];
 
+    struct timeval ts;
+
     /**
      * The scatter/gather list td_vbd_request_t.iov points to.
      */


### PR DESCRIPTION
Added new stats structure to account tapdisk traffic. Requests issued
from tapdisk to the vdi will be found in /dev/shm/td3-<pid>/vdi-<minor>

Signed-off-by: Jorge Martin <jorge.martin@citrix.com>