### PR TITLE
CA-148438: Expose mem_mode flag in statistics file

### DIFF
--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -154,6 +154,9 @@ struct td_vbd_handle {
 #define tapdisk_vbd_for_each_image(vbd, image, tmp)	\
 	tapdisk_for_each_image_safe(image, tmp, &vbd->images)
 
+#define tapdisk_vbd_for_each_blkif(vbd, blkif, tmp)	\
+	list_for_each_entry_safe((blkif), (tmp), (&vbd->rings), entry)
+
 static inline void
 tapdisk_vbd_move_request(td_vbd_request_t *vreq, struct list_head *dest)
 {

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -151,6 +151,10 @@ tapdisk_xenblkif_stats_create(struct td_xenblkif *blkif)
 
 	blkif->stats.xenvbd = blkif->xenvbd_stats.stats.mem;
 
+    if (tapdisk_server_mem_mode()) {
+        td_flag_set(blkif->stats.xenvbd->flags, BT3_LOW_MEMORY_MODE);
+    }
+
     err = tapdisk_xenblkif_ring_stats_update(blkif);
     if (unlikely(err)) {
         EPRINTF("failed to generate shared I/O ring stats: %s\n",

--- a/include/blktap3.h
+++ b/include/blktap3.h
@@ -30,6 +30,11 @@
 
 
 /**
+ * Flag defines
+ */
+#define BT3_LOW_MEMORY_MODE 0x0000000000000001
+
+/**
  * blkback-style stats
  */
 struct blkback_stats {
@@ -100,6 +105,13 @@ struct blkback_stats {
 	 * Absolute maximum BLKIF_OP_WRITE response time, in us.
 	 */
 	long long st_wr_max_usecs;
+
+	/**
+	 * Allocated space for 64 flags (due to 8-byte alignment)
+	 * 1st flag is LSB, last flag is MSB.
+	 * mem_mode: 0 - NORMAL_MEMORY_MODE; 1 - LOW_MEMORY_MODE;
+	 */
+	unsigned long long flags;
 } __attribute__ ((aligned (8)));
 
 #endif /* __BLKTAP_3_H__ */


### PR DESCRIPTION
Each tapdisk's memory mode state is now exposed in the respective
'/dev/shm/vbd3-*/statistics' memory mapped file. This will be
picked up by xcp-rrdd-iostat which will then aggregate it for the
total number of tapdisks on the host and expose a single rrd with
the total number of tapdisks in low memory mode.

See also CP-12967.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>