### PR TITLE
CA-186157: Adding extra fields to vbd3 stats structure.

### DIFF
--- a/drivers/tapdisk-metrics.c
+++ b/drivers/tapdisk-metrics.c
@@ -32,6 +32,8 @@
 #include "tapdisk-queue.h"
 #include "td-req.h"
 
+#define VBD_STATS_VERSION 0x00000001
+
 /* make a static metrics struct, so it only exists in the context of this file */
 static td_metrics_t td_metrics;
 
@@ -216,6 +218,7 @@ td_metrics_vbd_start(int domain, int id, stats_t *vbd_stats)
         goto out;
    }
     vbd_stats->stats = vbd_stats->shm.mem;
+    vbd_stats->stats->version = VBD_STATS_VERSION;
 out:
     return err;
 

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -24,6 +24,7 @@
 #define TAPDISK_METRICS_VBD_PATHF    "%s/vbd-%d-%d"
 #define TAPDISK_METRICS_BLKTAP_PATHF "%s/blktap-%d"
 #define TAPDISK_METRICS_NBD_PATHF "%s/nbd-%d"
+#define BT3_LOW_MEMORY_MODE 0x0000000000000001
 
 #include <libaio.h>
 
@@ -31,6 +32,8 @@
 #include "tapdisk.h"
 
 struct stats {
+    uint32_t version;
+    unsigned long long oo_reqs;
     unsigned long long read_reqs_submitted;
     unsigned long long read_reqs_completed;
     unsigned long long read_sectors;
@@ -39,6 +42,7 @@ struct stats {
     unsigned long long write_reqs_completed;
     unsigned long long write_sectors;
     unsigned long long write_total_ticks;
+    uint64_t flags;
 };
 
 typedef struct {

--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -480,8 +480,10 @@ static void lowmem_timeout(event_id_t id, char mode, void *data)
 	server.mem_state.mem_evid = -1;
 
 	tapdisk_server_for_each_vbd(vbd, tmpv)
-		tapdisk_vbd_for_each_blkif(vbd, blkif, tmpb)
+		tapdisk_vbd_for_each_blkif(vbd, blkif, tmpb) {
 			td_flag_clear(blkif->stats.xenvbd->flags, BT3_LOW_MEMORY_MODE);
+			td_flag_clear(blkif->vbd_stats.stats->flags, BT3_LOW_MEMORY_MODE);
+	}
 
 	if ((ret = tapdisk_server_reset_lowmem_mode()) < 0) {
 		ERR(-ret, "Failed to re-init low memory handler: %s\n",
@@ -544,8 +546,10 @@ static void lowmem_event(event_id_t id, char mode, void *data)
 	server.mem_state.mode = LOW_MEMORY_MODE;
 
 	tapdisk_server_for_each_vbd(vbd, tmpv)
-		tapdisk_vbd_for_each_blkif(vbd, blkif, tmpb)
+		tapdisk_vbd_for_each_blkif(vbd, blkif, tmpb) {
 			td_flag_set(blkif->stats.xenvbd->flags, BT3_LOW_MEMORY_MODE);
+			td_flag_set(blkif->vbd_stats.stats->flags, BT3_LOW_MEMORY_MODE);
+	}
 
 	/* Increment backoff up to a limit */
 	if (server.mem_state.backoff < MAX_BACKOFF)

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -154,6 +154,7 @@ tapdisk_xenblkif_stats_create(struct td_xenblkif *blkif)
 
     if (tapdisk_server_mem_mode()) {
         td_flag_set(blkif->stats.xenvbd->flags, BT3_LOW_MEMORY_MODE);
+        td_flag_set(blkif->vbd_stats.stats->flags, BT3_LOW_MEMORY_MODE);
     }
 
     err = tapdisk_xenblkif_ring_stats_update(blkif);


### PR DESCRIPTION
CA-186157: Adding extra fields to vbd3 stats structure.

The fields are:
1) version
2) oo_reqs
3) flags for low_mem_mode

Signed-off-by: Pritha Srivastava <pritha.srivastava@citrix.com>
Reviewed by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>