### PR TITLE
CA-186157: Extract tapdisk stats to separate header

### DIFF
--- a/drivers/tapdisk-metrics-stats.h
+++ b/drivers/tapdisk-metrics-stats.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.1 only
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+
+#ifndef TAPDISK_METRICS_STATS_H
+#define TAPDISK_METRICS_STATS_H
+
+#include <stdint.h>
+
+#define BT3_LOW_MEMORY_MODE 0x0000000000000001
+
+struct stats {
+    uint32_t version;
+    unsigned long long oo_reqs;
+    unsigned long long read_reqs_submitted;
+    unsigned long long read_reqs_completed;
+    unsigned long long read_sectors;
+    unsigned long long read_total_ticks;
+    unsigned long long write_reqs_submitted;
+    unsigned long long write_reqs_completed;
+    unsigned long long write_sectors;
+    unsigned long long write_total_ticks;
+    uint64_t io_errors;
+    uint64_t flags;
+};
+
+#endif /* TAPDISK_METRICS_STATS_H */

--- a/drivers/tapdisk-metrics.h
+++ b/drivers/tapdisk-metrics.h
@@ -24,27 +24,12 @@
 #define TAPDISK_METRICS_VBD_PATHF    "%s/vbd-%d-%d"
 #define TAPDISK_METRICS_BLKTAP_PATHF "%s/blktap-%d"
 #define TAPDISK_METRICS_NBD_PATHF "%s/nbd-%d"
-#define BT3_LOW_MEMORY_MODE 0x0000000000000001
 
 #include <libaio.h>
 
+#include "tapdisk-metrics-stats.h"
 #include "tapdisk-utils.h"
 #include "tapdisk.h"
-
-struct stats {
-    uint32_t version;
-    unsigned long long oo_reqs;
-    unsigned long long read_reqs_submitted;
-    unsigned long long read_reqs_completed;
-    unsigned long long read_sectors;
-    unsigned long long read_total_ticks;
-    unsigned long long write_reqs_submitted;
-    unsigned long long write_reqs_completed;
-    unsigned long long write_sectors;
-    unsigned long long write_total_ticks;
-    uint64_t io_errors;
-    uint64_t flags;
-};
 
 typedef struct {
     struct shm shm;

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -21,7 +21,7 @@ blktap_HEADERS += util.h
 blktap_HEADERS += payload.h
 blktap_HEADERS += kpr_util.h
 blktap_HEADERS += thin_log.h
-blktap_HEADERS += ../drivers/tapdisk-metrics.h
+blktap_HEADERS += ../drivers/tapdisk-metrics-stats.h
 
 noinst_HEADERS  = blktap.h
 noinst_HEADERS += compiler.h


### PR DESCRIPTION
Exported tapdisk-metrics.h is impossible to include,
since it contains dependencies to other blktap headers
which for now remains private (tapdisk.h, tapdisk-utils.h).

This patch moves tapdisk stats struct to a header
that does not contains other dependencies,
so that it can be included by other components
that need access to tapdisk statistics structure

Signed-off-by: Rafal Mielniczuk <rafal.mielniczuk@citrix.com>