### PR TITLE
CA-205513: Removing bad fds from the fdset passed to select call.

### DIFF
--- a/drivers/scheduler.c
+++ b/drivers/scheduler.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/time.h>
+#include <fcntl.h>
 
 #include "debug.h"
 #include "tapdisk.h"
@@ -100,6 +101,15 @@ scheduler_prepare_events(scheduler_t *s)
 	scheduler_for_each_event(s, event) {
 		if (event->masked || event->dead)
 			continue;
+
+		if (event->mode & SCHEDULER_POLL_FD &&
+			(fcntl(event->fd, F_GETFL) < 0) &&
+			errno == EBADF)
+		{
+			EPRINTF("EBADF: Marking event dead, id: %d", event->id);
+			event->dead = 1;
+			continue;
+		}
 
 		if (event->mode & SCHEDULER_POLL_READ_FD) {
 			FD_SET(event->fd, &s->read_fds);


### PR DESCRIPTION
SCTX-2269: Removing bad fds from the fdset passed to select call.

This will prevent the select call from failing because of a bad fd.

Signed-off-by: Pritha Srivastava <pritha.srivastava@citrix.com>