### PR TITLE
Change 'datasource type' of reported stats

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1126,7 +1126,7 @@ tapdisk_vbd_produce_rrds(td_vbd_t *vbd) {
 			"\"description\": \"Number of I/O errors\",\n");
 	err += tapdisk_snprintf(buf, &off, &size, 3, "\"owner\": \"host\",\n");
 	err += tapdisk_snprintf(buf, &off, &size, 3,  "\"type\": "
-			"\"absolute\",\n");
+			"\"gauge\",\n");
 	err += tapdisk_snprintf(buf, &off, &size, 3, "\"units\": \"units\",\n");
 	err += tapdisk_snprintf(buf, &off, &size, 3, "\"min\": \"0.00\",\n");
 	err += tapdisk_snprintf(buf, &off, &size, 3, "\"max\": \"inf\",\n");


### PR DESCRIPTION
Commit 793605d4357f4f229bf229ff5e45966f27e0ef93 under
xapi-project/rrd-transport matches the datasource type
name used internally by the RRD daemon with the name
datasources must report. In this case, 'absolute' must
be changed to 'gauge'

Signed-off-by: Kostas Ladopoulos Konstantinos.Ladopoulos@citrix.com
