### PR TITLE
CA-217394: XSO-587 ERROR: errno -12 at tapdisk_control_accept

### DIFF
--- a/drivers/scheduler.c
+++ b/drivers/scheduler.c
@@ -294,8 +294,8 @@ scheduler_register_event(scheduler_t *s, char mode, int fd,
 	event->id       = s->uuid++;
 	event->masked   = 0;
 
-	if (!s->uuid)
-		s->uuid++;
+	if (s->uuid < 0)
+		s->uuid = 1;
 
 	list_add_tail(&event->next, &s->events);
 


### PR DESCRIPTION
Prevent negative ids getting assigned to valid events in
tapdisk scheduler

Signed-off-by: Sharath Babu Sharath.Babu@citrix.com
