### PR TITLE
CA-220434: Return 'err' instead of 0

### DIFF
--- a/control/tap-ctl-list.c
+++ b/control/tap-ctl-list.c
@@ -306,7 +306,7 @@ _tap_ctl_list_tapdisk(pid_t pid, struct list_head *list)
 	err = 0;
 out:
 	close(sfd);
-	return 0;
+	return err;
 
 fail:
 	tap_ctl_list_free(list);


### PR DESCRIPTION
'_tap_ctl_list_tapdisk()' returned 0, regardless of success/failure.
'err' is saved throughout the function, so return it instead of 0.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
