### PR TITLE
CA-220436: Fix Resource leak in tap-ctl-list.c

### DIFF
--- a/control/tap-ctl-list.c
+++ b/control/tap-ctl-list.c
@@ -267,7 +267,7 @@ _tap_ctl_list_tapdisk(pid_t pid, struct list_head *list)
 
 	err = tap_ctl_write_message(sfd, &message, &timeout);
 	if (err)
-		return err;
+		goto out;
 
 	INIT_LIST_HEAD(list);
 


### PR DESCRIPTION
Socket fd was being leaked if tap_ctl_write_message() failed in
_tap_ctl_list_tapdisk().

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com

*N.B.: Accept PR 200 before this one.
