### PR TITLE
CA-220442: Check length of socket name before copying

### DIFF
--- a/control/tap-ctl-ipc.c
+++ b/control/tap-ctl-ipc.c
@@ -187,6 +187,13 @@ tap_ctl_connect(const char *name, int *sfd)
 
 	memset(&saddr, 0, sizeof(saddr));
 	saddr.sun_family = AF_UNIX;
+
+	if (unlikely(strlen(name) >= sizeof(saddr.sun_path))) {
+		EPRINTF("socket name too long: %s\n", name);
+		close(fd);
+		return -ENAMETOOLONG;
+	}
+
 	strcpy(saddr.sun_path, name);
 
 	err = connect(fd, (const struct sockaddr *)&saddr, sizeof(saddr));


### PR DESCRIPTION
'struct sockaddr_un' member 'sun_path' is a fixed size, 108 byte array.
Check that 'name' is at maximum 107 characters long before copying.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
