### PR TITLE
CA-220444: Fix possible race condition

### DIFF
--- a/control/tap-ctl-allocate.c
+++ b/control/tap-ctl-allocate.c
@@ -107,11 +107,13 @@ tap_ctl_make_device(const char *devname, const int major,
 	if (err)
 		return err;
 
-	if (!access(devname, F_OK))
-		if (unlink(devname)) {
+	if (unlink(devname)) {
+		err = errno;
+		if (err != ENOENT) {
 			PERROR("unlink %s", devname);
-			return errno;
+			return err;
 		}
+	}
 
 	err = mknod(devname, perm, makedev(major, minor));
 	if (err) {


### PR DESCRIPTION
In function tap_ctl_make_device() in tap-ctl-allocate.c, try to unlink
without checking if the device is there first. If it does not exist, do
nothing. For all other errors, return 'errno'.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
