### PR TITLE
CA-220478: Fix leaked socket file descriptor

### DIFF
--- a/control/tap-ctl-stats.c
+++ b/control/tap-ctl-stats.c
@@ -55,8 +55,10 @@ _tap_ctl_stats_connect_and_send(pid_t pid, int minor)
 	message.cookie = minor;
 
 	err = tap_ctl_write_message(sfd, &message, &timeout);
-	if (err)
+	if (err) {
+		close(sfd);
 		return err;
+	}
 
 	return sfd;
 }


### PR DESCRIPTION
In _tap_ctl_stats_connect_and_send(), if tap_ctl_write_message()
returns an error, 'sfd' is not closed before returning.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
