### PR TITLE
CA-220463: Ensure string fits in buffer before copying

### DIFF
--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -70,10 +70,15 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
     message.u.blkif.proto = proto;
     message.u.blkif.poll_duration = poll_duration;
     message.u.blkif.poll_idle_threshold = poll_idle_threshold;
-    if (pool)
-        strncpy(message.u.blkif.pool, pool, sizeof(message.u.blkif.pool));
-    else
+    if (pool) {
+        if (unlikely(strlen(pool) > (sizeof(message.u.blkif.pool) - 1))) {
+            EPRINTF("pool name too long: %s\n", pool);
+            return -ENAMETOOLONG;
+        }
+        strcpy(message.u.blkif.pool, pool);
+    } else {
         message.u.blkif.pool[0] = 0;
+    }
 
     err = tap_ctl_connect_send_and_receive(pid, &message, NULL);
     if (err || message.type == TAPDISK_MESSAGE_ERROR) {


### PR DESCRIPTION
'message.u.blkif.pool' is a fixed size char array. Make sure the C
string pointed to by 'pool' (with the terminateing '\0' char) fits
before copying it over.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
