### PR TITLE
CA-220481: Fixes in tap_ctl_stats_fwrite()

### DIFF
--- a/control/tap-ctl-stats.c
+++ b/control/tap-ctl-stats.c
@@ -105,11 +105,17 @@ tap_ctl_stats_fwrite(pid_t pid, int minor, FILE *stream)
 
 	prot  = PROT_READ|PROT_WRITE;
 	flags = MAP_ANONYMOUS|MAP_PRIVATE;
-	bufsz = sysconf(_SC_PAGE_SIZE);
+
+	err = sysconf(_SC_PAGE_SIZE);
+	if (err == -1) {
+		err = -errno;
+		goto out;
+	}
+
+	bufsz = err;
 
 	buf = mmap(NULL, bufsz, prot, flags, -1, 0);
 	if (buf == MAP_FAILED) {
-		buf = NULL;
 		err = -ENOMEM;
 		goto out;
 	}


### PR DESCRIPTION
- Ensure that 'sysconf()' returns a positive value before assigning
  to 'bufz'. Otherwise, set 'err' and jump to 'out'
- In case 'mmap()' returns 'MAP_FAILED', do not change 'buf'
  to 'NULL' before jumping to 'out'; if 'buf != MAP_FAILED'
  'munmap(buf, bufsz)' is called

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
