### PR TITLE
CA-220482: Check return value of fwrite()

### DIFF
--- a/control/tap-ctl-stats.c
+++ b/control/tap-ctl-stats.c
@@ -158,7 +158,10 @@ tap_ctl_stats_fwrite(pid_t pid, int minor, FILE *stream)
 			goto out;
 		}
 	}
-	len = fwrite("\n", 1, 1, stream);
+
+	if (fwrite("\n", 1, 1, stream) != 1) {
+		err = -EIO;
+	}
 
 out:
 	if (sfd >= 0)


### PR DESCRIPTION
'len' is unused, so do not save the return value of 'fwrite()';
instead, check that it was successful, and if not, set 'err'
appropriately.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
