### PR TITLE
CA-220515: Return correct error val in vhd_util_pathcmp()

### DIFF
--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -258,13 +258,13 @@ vhd_util_pathcmp(const char *a, const char *b, int *cmp)
 
 	apath = canonpath(a, __apath);
 	if (!apath) {
-		err = -errno;
+		err = -ENOENT;
 		goto out;
 	}
 
 	bpath = canonpath(b, __bpath);
 	if (!bpath) {
-		err = -errno;
+		err = -ENOENT;
 		goto out;
 	}
 


### PR DESCRIPTION
'canonpath()' does not set 'errno' in case of error, so it is
useless using it in 'vhd_util_pathcmp()'.

Return '-ENOENT' instead.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>