### PR TITLE
CA-220467: Add coverity fixes for tapdisk-nbdserver.c

### DIFF
--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -834,6 +834,14 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 	}
 
 	server->local.sun_family = AF_UNIX;
+
+	if (unlikely(strlen(server->sockpath) > 
+		     (sizeof(server->local.sun_path) - 1))) {
+		err = -ENAMETOOLONG;
+		ERR("socket name too long: %s\n", server->sockpath);
+		goto out;
+	}
+
 	strcpy(server->local.sun_path, server->sockpath);
 	err = unlink(server->local.sun_path);
 	if (err == -1 && errno != ENOENT) {

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -94,8 +94,8 @@ tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 	return req;
 }
 
-void
-tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
+static void
+tapdisk_nbdserver_set_free_request(td_nbdserver_client_t *client,
 		td_nbdserver_req_t *req)
 {
 	ASSERT(client);
@@ -103,7 +103,13 @@ tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
 	BUG_ON(client->n_reqs_free >= client->n_reqs);
 
 	client->reqs_free[client->n_reqs_free++] = req;
+}
 
+void
+tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
+		td_nbdserver_req_t *req)
+{
+	tapdisk_nbdserver_set_free_request(client, req);
 	if (unlikely(client->dead && !tapdisk_nbdserver_reqs_pending(client)))
 		tapdisk_nbdserver_free_client(client);
 }
@@ -160,7 +166,7 @@ tapdisk_nbdserver_reqs_init(td_nbdserver_client_t *client, int n_reqs)
 
 	for (i = 0; i < n_reqs; i++) {
 		client->reqs[i].vreq.iov = &client->iovecs[i];
-		tapdisk_nbdserver_free_request(client, &client->reqs[i]);
+		tapdisk_nbdserver_set_free_request(client, &client->reqs[i]);
 	}
 
 	return 0;

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -772,6 +772,7 @@ tapdisk_nbdserver_listen_inet(td_nbdserver_t *server, const int port)
 					&yes, sizeof(int)) == -1) {
 			ERR("Failed to setsockopt");
 			close(server->fdrecv_listening_fd);
+			server->fdrecv_listening_fd = -1;
 			continue;
 		}
 
@@ -779,6 +780,7 @@ tapdisk_nbdserver_listen_inet(td_nbdserver_t *server, const int port)
 				-1) {
 			ERR("Failed to bind");
 			close(server->fdrecv_listening_fd);
+			server->fdrecv_listening_fd = -1;
 			continue;
 		}
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -383,10 +383,16 @@ tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
 		else
 			INFO("Short write in negotiation: wrote %d bytes instead of 152\n",
 					rc);
+		return;
 	}
 
 	INFO("About to alloc client");
 	client = tapdisk_nbdserver_alloc_client(server);
+	if (client == NULL) {
+		ERR("Error allocating client");
+		close(new_fd);
+		return;
+	}
 
 	INFO("Got an allocated client at %p", client);
 	client->client_fd = new_fd;


### PR DESCRIPTION
This includes fixes for all coverity bugs related to tapdisk-nbdserver.c

CID-11258: Unchecked return value from library
CID-28562: Dereference null return value
CID-28703: Destination buffer too small
CID-28739: Double close
CID-57555: Read from pointer after free
CID-62178: Write to pointer after free

Please see every commit message for every specific fix.
