### PR TITLE
CA-220518: Potentially uninitialised variable used

### DIFF
--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -418,7 +418,8 @@ vhd_util_coalesce_clear_bitmap(vhd_context_t *child, char *cmap,
 			       vhd_context_t *ancestor, const uint64_t block)
 {
 	char *amap = NULL;
-	int i, dirty, err;
+	int dirty = 0;
+	int i, err;
 
 	if (child->spb != ancestor->spb) {
 		err = -EINVAL;


### PR DESCRIPTION
In 'vhd_util_coalesce_clear_bitmap()', 'dirty' is used in a truth
statement, potentially uninitialised.

Initialise to 0.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
