### PR TITLE
CA-216250: Fix resource leak

### DIFF
--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -410,6 +410,11 @@ out:
 		}
 		vhd_util_coalesce_free_chain(head);
 	}
+
+	if (next) {
+		free(next);
+	}
+
 	return err;
 }
 


### PR DESCRIPTION
In 'vhd_util_coalesce_load_chain()', if there is an error and we
jump to 'out', 'next' might not be freed.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
