### PR TITLE
CA-220808: Do not free unallocated pointers in vhd_close()

### DIFF
--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -2668,12 +2668,21 @@ vhd_close(vhd_context_t *ctx)
 	if (ctx->file) {
 		fsync(ctx->fd);
 		close(ctx->fd);
+		free(ctx->file);
 	}
 
-	free(ctx->file);
-	free(ctx->bat.bat);
-	free(ctx->batmap.map);
-	free(ctx->custom_parent);
+	if (ctx->bat.bat) {
+		free(ctx->bat.bat);
+	}
+
+	if (ctx->batmap.map) {
+		free(ctx->batmap.map);
+	}
+
+	if (ctx->custom_parent) {
+		free(ctx->custom_parent);
+	}
+
 	memset(ctx, 0, sizeof(vhd_context_t));
 }
 


### PR DESCRIPTION
In the beginning of 'vhd_open()', 'ctx' is memset to 0; memory is
not allocated to all of the pointers in the object. When calling
'vhd_close()', check if all pointers are different from 0 before
freeing them.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>