### PR TITLE
CA-222003: Fix NULL dereference bug

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -126,6 +126,10 @@ tapdisk_vbd_initialize(int rfd, int wfd, uint16_t uuid)
 	}
 
 	vbd = tapdisk_vbd_create(uuid);
+	if (!vbd) {
+		EPRINTF("failed to create vbd\n");
+		return -ENOMEM;
+	}
 
 	tapdisk_server_add_vbd(vbd);
 


### PR DESCRIPTION
In function 'tapdisk_vbd_initialize()' check the return value of
'tapdisk_vbd_create()' before proceeding; it might be NULL.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
