### PR TITLE
CA-216249: Check length of socket name before copying

### DIFF
--- a/drivers/block-valve.c
+++ b/drivers/block-valve.c
@@ -226,10 +226,14 @@ valve_sock_open(td_valve_t *valve)
 
 	valve->sock = s;
 
-	if (valve->brname[0] == '/')
-		strncpy(addr.sun_path, valve->brname,
-			sizeof(addr.sun_path));
-	else
+	if (valve->brname[0] == '/') {
+		if (unlikely(strlen(valve->brname) >= sizeof(addr.sun_path))) {
+			ERR("socket name too long: %s\n", valve->brname);
+			err = -ENAMETOOLONG;
+			goto fail;
+		}
+		strcpy(addr.sun_path, valve->brname);
+	} else
 		snprintf(addr.sun_path, sizeof(addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, valve->brname);
 

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1506,7 +1506,14 @@ tapdisk_control_create_socket(char **socket_path)
 	}
 
 	memset(&saddr, 0, sizeof(saddr));
-	strncpy(saddr.sun_path, td_control.path, sizeof(saddr.sun_path));
+
+	if (unlikely(strlen(td_control.path) >= sizeof(saddr.sun_path))) {
+		EPRINTF("socket name too long: %s\n", td_control.path);
+		err = ENAMETOOLONG;
+		goto fail;
+	}
+	strcpy(saddr.sun_path, td_control.path);
+
 	saddr.sun_family = AF_UNIX;
 
 	err = bind(td_control.socket,

--- a/drivers/td-rated.c
+++ b/drivers/td-rated.c
@@ -401,10 +401,14 @@ rlb_sock_open(td_rlb_t *rlb)
 
 	rlb->addr.sun_family = AF_UNIX;
 
-	if (rlb->name[0] == '/')
-		strncpy(rlb->addr.sun_path, rlb->name,
-			sizeof(rlb->addr.sun_path));
-	else
+	if (rlb->name[0] == '/') {
+		if (unlikely(strlen(rlb->name) >= sizeof(rlb->addr.sun_path))) {
+			ERR("socket name too long: %s\n", rlb->name);
+			err = -ENAMETOOLONG;
+			goto fail;
+		}
+		strcpy(rlb->addr.sun_path, rlb->name);
+	} else
 		snprintf(rlb->addr.sun_path, sizeof(rlb->addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, rlb->name);
 


### PR DESCRIPTION
Ensure that string fits in 'sun_path' before copying it over.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
