### PR TITLE
CA-222139: Resource leak in tap_ctl_allocate_device()

### DIFF
--- a/control/tap-ctl-allocate.c
+++ b/control/tap-ctl-allocate.c
@@ -166,6 +166,7 @@ tap_ctl_allocate_device(int *minor, char **devname)
 	char *name;
 	int fd, err;
 	struct blktap2_handle handle;
+	char free_devname = 0;
 
 	*minor = -1;
 	if (!devname)
@@ -209,6 +210,7 @@ tap_ctl_allocate_device(int *minor, char **devname)
 			goto fail;
 		}
 		*devname = name;
+		free_devname = 1;
 	}
 
 	err = tap_ctl_make_device(name, handle.device,
@@ -226,6 +228,10 @@ tap_ctl_allocate_device(int *minor, char **devname)
 	return 0;
 
 fail:
+	if (free_devname) {
+		free(*devname);
+		*devname = 0;
+	}
 	tap_ctl_free(handle.minor);
 	return err;
 }

--- a/control/tap-ctl.c
+++ b/control/tap-ctl.c
@@ -192,6 +192,7 @@ tap_cli_allocate(int argc, char **argv)
 {
 	char *devname;
 	int c, minor, err;
+	char d_flag = 0;
 
 	devname = NULL;
 
@@ -200,6 +201,7 @@ tap_cli_allocate(int argc, char **argv)
 		switch (c) {
 		case 'd':
 			devname = optarg;
+			d_flag = 1;
 			break;
 		case '?':
 			goto usage;
@@ -212,6 +214,9 @@ tap_cli_allocate(int argc, char **argv)
 	err = tap_ctl_allocate(&minor, &devname);
 	if (!err)
 		printf("%s\n", devname);
+
+	if (!d_flag)
+		free(devname);
 
 	return err;
 
@@ -273,6 +278,7 @@ tap_cli_create(int argc, char **argv)
 {
 	int c, err, flags, prt_minor, timeout;
 	char *args, *devname, *secondary;
+	char d_flag = 0;
 
 	args      = NULL;
 	devname   = NULL;
@@ -289,6 +295,7 @@ tap_cli_create(int argc, char **argv)
 			break;
 		case 'd':
 			devname = optarg;
+			d_flag = 1;
 			break;
 		case 'R':
 			flags |= TAPDISK_MESSAGE_FLAG_RDONLY;
@@ -328,6 +335,9 @@ tap_cli_create(int argc, char **argv)
 			timeout);
 	if (!err)
 		printf("%s\n", devname);
+
+	if (!d_flag)
+		free(devname);
 
 	return err;
 


### PR DESCRIPTION
tap_ctl_allocate_device() will allocate memory to *devname, if it does
not already point to a command line argument. That memory needs to be
freed in both the success (in the calling function) and failure (in
the same function) cases.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
