### PR TITLE
CA-217896: tapdisk segfault

### DIFF
--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -705,15 +705,19 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
 	tapreq->vma = NULL;
     switch (tapreq->msg.operation) {
     case BLKIF_OP_READ:
-        blkif->stats.xenvbd->st_rd_req++;
-        blkif->vbd_stats.stats->read_reqs_submitted++;
+	if (likely(!blkif->dead)) {
+        	blkif->stats.xenvbd->st_rd_req++;
+        	blkif->vbd_stats.stats->read_reqs_submitted++;
+	}
         tapreq->prot = PROT_WRITE;
         vreq->op = TD_OP_READ;
         break;
     case BLKIF_OP_WRITE:
     case BLKIF_OP_WRITE_BARRIER:
-        blkif->stats.xenvbd->st_wr_req++;
-        blkif->vbd_stats.stats->write_reqs_submitted++;
+	if (likely(!blkif->dead)) {
+        	blkif->stats.xenvbd->st_wr_req++;
+	        blkif->vbd_stats.stats->write_reqs_submitted++;
+	}
         tapreq->prot = PROT_READ;
         vreq->op = TD_OP_WRITE;
         break;


### PR DESCRIPTION
Tapdisk seg fault occured when a ring had pending
requests and is destroyed during a hard VM shutdown.
Those pending requests try to update the stats
which leads to a seg fault. Hence, gurading updates
to blkif->stats using blkif->dead during tapdisk
request operations.

Signed-off-by: Sharath Babu sharath.babu@citrix.com
