### PR TITLE
CA-222242: memset() 1 byte instead of 4

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -384,7 +384,7 @@ vhd_kill_footer(struct vhd_state *s)
 		return -err;
 
 	err = 1;
-	memset(zeros, 0xc7c7c7c7, 512);
+	memset(zeros, 0xc7, 512);
 
 	if ((end = lseek64(s->vhd.fd, 0, SEEK_END)) == -1)
 		goto fail;


### PR DESCRIPTION
In 'vhd_kill_footer()', we call 'memset()' passing a 4 byte value
instead of a 1 byte value, as expected. Everything after the first
byte is truncated.

Signed-off-by: Kostas Ladopoulos konstantinos.ladopoulos@citrix.com
