### PR TITLE
CA-222124: Handle race-condition in tap-ctl spawn

### DIFF
--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1452,11 +1452,15 @@ tapdisk_control_mkdir(const char *dir)
 			*ptr = '\0';
 
 		err = mkdir(name, 0755);
-		if (err && errno != EEXIST) {
-			err = -errno;
-			EPRINTF("failed to create directory %s: %d\n",
-				  name, err);
-			break;
+		if (err) {
+			if (errno != EEXIST) {
+				err = -errno;
+				EPRINTF("failed to create directory %s: %d\n",
+					name, err);
+				break;
+			}
+			else
+				err = 0;
 		}
 
 		if (!ptr)


### PR DESCRIPTION
When two tapdisk processes are spawned at the same time, they race
to create the /var/run/blktap-control directory. We currently don't handle
the error condition EEXIST where one tapdisk process finds that
the directory already exists.

Signed-off-by: Chandrika Srinivasan chandrika.srinivasan@citrix.com
