### PR TITLE
Add a check to force O_DSYNC if needed

### DIFF
--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -2575,8 +2575,17 @@ vhd_open(vhd_context_t *ctx, const char *file, int flags)
 		return err;
 
 	oflags = O_LARGEFILE;
-	if (!(flags & VHD_OPEN_CACHED))
+	if (!(flags & VHD_OPEN_CACHED)) {
 		oflags |= O_DIRECT;
+		if (access("/etc/tapdisk_use_dsync", F_OK) != -1) {
+		/* tapdisk_use_dsync exists, it means we need to open
+		 * the leaf with O_DSYNC as well.
+		 * This is not a public tapdisk interface
+		 */
+			if (!(flags & VHD_OPEN_RDONLY))
+				oflags |= O_DSYNC;
+		}
+	}
 	if (flags & VHD_OPEN_RDONLY)
 		oflags |= O_RDONLY;
 	if (flags & VHD_OPEN_RDWR)


### PR DESCRIPTION
In order to be able to open the VHD leaf with O_DSYNC
we now have a check for the existence of a file.

The file is /etc/tapdisk_use_dsync

If the file exists the option O_DSYNC is added to O_DIRECT.

This is not a public interface, but just an hardcoded debug
interface.

Signed-off-by: Stefano Panella <stefano.panella@citrix.com>