### PR TITLE
CA-294079 Revert "CA-205513: Removing bad fds from the fdset passed t…

### DIFF
--- a/drivers/scheduler.c
+++ b/drivers/scheduler.c
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/time.h>
-#include <fcntl.h>
 
 #include "debug.h"
 #include "tapdisk.h"
@@ -115,15 +114,6 @@ scheduler_prepare_events(scheduler_t *s)
 	scheduler_for_each_event(s, event) {
 		if (event->masked || event->dead)
 			continue;
-
-		if (event->mode & SCHEDULER_POLL_FD &&
-			(fcntl(event->fd, F_GETFL) < 0) &&
-			errno == EBADF)
-		{
-			EPRINTF("EBADF: Marking event dead, id: %d", event->id);
-			event->dead = 1;
-			continue;
-		}
 
 		if (event->mode & SCHEDULER_POLL_READ_FD) {
 			FD_SET(event->fd, &s->read_fds);


### PR DESCRIPTION
…o select call."

This reverts commit 19e0f00c8b73372e7ab53b8e10af0219f829bc17.

The underlying problem was fixed by:

    commit 397c5486da1ea16eef47b0aef33553135ea07df7
    CA-217394: Handle scheduler uuid data type overflow in tapdisk

Calling fcntl(fd, F_GETFL) on every event was causing a performance
degradation in conditions where tapdisk was CPU bound (small block size
I/O or fast storage).

Signed-off-by: Tim Smith <tim.smith@citrix.com>