### PR TITLE
[RFC]: add discard support for vhd

### DIFF
--- a/control/tap-ctl-info.c
+++ b/control/tap-ctl-info.c
@@ -36,7 +36,8 @@
 #include "tap-ctl.h"
 
 int tap_ctl_info(pid_t pid, unsigned long long *sectors,
-		unsigned int *sector_size, unsigned int *info, const int minor)
+				 unsigned int *sector_size, unsigned int *info,
+				 bool *discard, const int minor)
 {
     tapdisk_message_t message;
     int err;
@@ -60,6 +61,7 @@ int tap_ctl_info(pid_t pid, unsigned long long *sectors,
         *sectors = message.u.image.sectors;
         *sector_size = message.u.image.sector_size;
         *info = message.u.image.info;
+		*discard = message.u.image.discard;
         return 0;
     } else if (TAPDISK_MESSAGE_ERROR == message.type) {
        return -message.u.response.error;

--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -203,12 +203,12 @@ struct vhd_bitmap {
 
 	char                     *map;         /* map should only be modified
 					        * in finish_bitmap_write */
-	char                     *shadow;      /* in-memory bitmap changes are 
+	char                     *shadow;      /* in-memory bitmap changes are
 					        * made to shadow and copied to
 					        * map only after having been
 					        * flushed to disk */
 	struct vhd_transaction    tx;          /* transaction data structure
-						* encapsulating data, bitmap, 
+						* encapsulating data, bitmap,
 						* and bat writes */
 	struct vhd_req_list       queue;       /* data writes waiting for next
 						* transaction */
@@ -677,7 +677,7 @@ __vhd_open(td_driver_t *driver, const char *name, vhd_flag_t flags)
 	if (err)
 		return err;
 
-	o_flags = ((test_vhd_flag(flags, VHD_FLAG_OPEN_RDONLY)) ? 
+	o_flags = ((test_vhd_flag(flags, VHD_FLAG_OPEN_RDONLY)) ?
 		   VHD_OPEN_RDONLY : VHD_OPEN_RDWR);
 	if ((test_vhd_flag(flags, VHD_FLAG_OPEN_RDONLY) ||
                 test_vhd_flag(flags, VHD_FLAG_OPEN_LOCAL_CACHE)) &&
@@ -725,7 +725,7 @@ __vhd_open(td_driver_t *driver, const char *name, vhd_flag_t flags)
         DBG(TLOG_INFO, "vhd_open: done (sz:%"PRIu64", sct:%lu, inf:%u)\n",
 	    driver->info.size, driver->info.sector_size, driver->info.info);
 
-	if (test_vhd_flag(flags, VHD_FLAG_OPEN_STRICT) && 
+	if (test_vhd_flag(flags, VHD_FLAG_OPEN_STRICT) &&
 	    !test_vhd_flag(flags, VHD_FLAG_OPEN_RDONLY)) {
 		err = vhd_kill_footer(s);
 		if (err) {
@@ -803,21 +803,21 @@ _vhd_close(td_driver_t *driver)
 {
 	int err;
 	struct vhd_state *s;
-	
+
 	DBG(TLOG_WARN, "vhd_close\n");
 	s = (struct vhd_state *)driver->data;
 
-	DPRINTF("gaps written/skipped: %ld/%ld\n", 
+	DPRINTF("gaps written/skipped: %ld/%ld\n",
 			s->debug_done_redundant_writes,
 			s->debug_skipped_redundant_writes);
 
 	/* don't write footer if tapdisk is read-only */
 	if (test_vhd_flag(s->flags, VHD_FLAG_OPEN_RDONLY))
 		goto free;
-	
-	/* 
+
+	/*
 	 * write footer if:
-	 *   - we killed it on open (opened with strict) 
+	 *   - we killed it on open (opened with strict)
 	 *   - we've written data since opening
 	 */
 	if (test_vhd_flag(s->flags, VHD_FLAG_OPEN_STRICT) || s->writes) {
@@ -867,7 +867,7 @@ vhd_validate_parent(td_driver_t *child_driver,
 
 	parent = (struct vhd_state *)parent_driver->data;
 
-	/* 
+	/*
 	 * This check removed because of cases like:
 	 *   - parent VHD marked as 'hidden'
 	 *   - parent VHD modified during coalesce
@@ -893,7 +893,7 @@ vhd_validate_parent(td_driver_t *child_driver,
 	}
 
 	/* TODO: compare sizes */
-	
+
 	return 0;
 }
 
@@ -934,9 +934,9 @@ clear_req_list(struct vhd_req_list *list)
 static inline void
 add_to_tail(struct vhd_req_list *list, struct vhd_request *e)
 {
-	if (!list->head) 
+	if (!list->head)
 		list->head = list->tail = e;
-	else 
+	else
 		list->tail = list->tail->next = e;
 }
 
@@ -1136,7 +1136,7 @@ static int
 alloc_vhd_bitmap(struct vhd_state *s, struct vhd_bitmap **bitmap, uint32_t blk)
 {
 	struct vhd_bitmap *bm;
-	
+
 	*bitmap = NULL;
 
 	if (s->bm_free_count > 0) {
@@ -1220,7 +1220,7 @@ read_bitmap_cache(struct vhd_state *s, uint64_t sector, uint8_t op)
 	struct vhd_bitmap *bm;
 
 	/* in fixed disks, every block is present */
-	if (s->vhd.footer.type == HD_TYPE_FIXED) 
+	if (s->vhd.footer.type == HD_TYPE_FIXED)
 		return VHD_BM_BIT_SET;
 
 	/* the extent the logical sector falls in */
@@ -1258,12 +1258,12 @@ read_bitmap_cache(struct vhd_state *s, uint64_t sector, uint8_t op)
 	if (test_vhd_flag(bm->status, VHD_FLAG_BM_READ_PENDING))
 		return VHD_BM_READ_PENDING;
 
-	return ((vhd_bitmap_test(&s->vhd, bm->map, sec)) ? 
+	return ((vhd_bitmap_test(&s->vhd, bm->map, sec)) ?
 		VHD_BM_BIT_SET : VHD_BM_BIT_CLEAR);
 }
 
 static int
-read_bitmap_cache_span(struct vhd_state *s, 
+read_bitmap_cache_span(struct vhd_state *s,
 		       uint64_t sector, int nr_secs, int value)
 {
 	int ret;
@@ -1271,7 +1271,7 @@ read_bitmap_cache_span(struct vhd_state *s,
 	struct vhd_bitmap *bm;
 
 	/* in fixed disks, every block is present */
-	if (s->vhd.footer.type == HD_TYPE_FIXED) 
+	if (s->vhd.footer.type == HD_TYPE_FIXED)
 		return nr_secs;
 
 	sec = sector % s->spb;
@@ -1281,7 +1281,7 @@ read_bitmap_cache_span(struct vhd_state *s,
 		return MIN(nr_secs, s->spb - sec);
 
 	bm  = get_bitmap(s, blk);
-	
+
 	ASSERT(bm && bitmap_valid(bm));
 
 	for (ret = 0; sec < s->spb && ret < nr_secs; sec++, ret++)
@@ -1295,7 +1295,7 @@ static inline struct vhd_request *
 alloc_vhd_request(struct vhd_state *s)
 {
 	struct vhd_request *req = NULL;
-	
+
 	if (s->vreq_free_count > 0) {
 		req = s->vreq_free[--s->vreq_free_count];
 		ASSERT(req->treq.secs == 0);
@@ -1455,22 +1455,22 @@ schedule_zero_bm_write(struct vhd_state *s,
 	aio_write(s, req, offset);
 }
 
-/* This is a performance optimization. When writing sequentially into full 
- * blocks, skipping (up-to-date) bitmaps causes an approx. 25% reduction in 
- * throughput. To prevent skipping, we issue redundant writes into the (padded) 
- * bitmap area just to make all writes sequential. This will help VHDs on raw 
+/* This is a performance optimization. When writing sequentially into full
+ * blocks, skipping (up-to-date) bitmaps causes an approx. 25% reduction in
+ * throughput. To prevent skipping, we issue redundant writes into the (padded)
+ * bitmap area just to make all writes sequential. This will help VHDs on raw
  * block devices, while the FS-based VHDs shouldn't suffer much.
  *
- * Note that it only makes sense to perform this reduntant bitmap write if the 
- * block is completely full (i.e. the batmap entry is set). If the block is not 
+ * Note that it only makes sense to perform this reduntant bitmap write if the
+ * block is completely full (i.e. the batmap entry is set). If the block is not
  * completely full then one of the following two things will be true:
  *  1. we'll either be allocating new sectors in this block and writing its
  *     bitmap transactionally, which will be slow anyways; or
  *  2. the IO will be skipping over the unallocated sectors again, so the
  *     pattern will not be sequential anyways
- * In either case a redundant bitmap write becomes pointless. This fact 
- * simplifies the implementation of redundant writes: since we know the bitmap 
- * cannot be updated by anyone else, we don't have to worry about transactions 
+ * In either case a redundant bitmap write becomes pointless. This fact
+ * simplifies the implementation of redundant writes: since we know the bitmap
+ * cannot be updated by anyone else, we don't have to worry about transactions
  * or potential write conflicts.
  * */
 static void
@@ -1483,7 +1483,7 @@ schedule_redundant_bm_write(struct vhd_state *s, uint32_t blk)
 	ASSERT(test_batmap(s, blk));
 
 	req = alloc_vhd_request(s);
-	if (!req) 
+	if (!req)
 		return;
 
 	req->treq.buf = s->padbm_buf;
@@ -1512,7 +1512,7 @@ update_bat(struct vhd_state *s, uint32_t blk)
 	struct vhd_bitmap *bm;
 
 	ASSERT(bat_entry(s, blk) == DD_BLK_UNUSED);
-	
+
 	if (bat_locked(s)) {
 		ASSERT(s->bat.pbw_blk == blk);
 		return 0;
@@ -1524,7 +1524,7 @@ update_bat(struct vhd_state *s, uint32_t blk)
 	if (!bm) {
 		/* install empty bitmap in cache */
 		err = alloc_vhd_bitmap(s, &bm, blk);
-		if (err) 
+		if (err)
 			return err;
 
 		install_bitmap(s, bm);
@@ -1601,7 +1601,7 @@ allocate_block(struct vhd_state *s, uint32_t blk)
 	if (!bm) {
 		/* install empty bitmap in cache */
 		err = alloc_vhd_bitmap(s, &bm, blk);
-		if (err) 
+		if (err)
 			return err;
 
 		install_bitmap(s, bm);
@@ -1615,7 +1615,7 @@ allocate_block(struct vhd_state *s, uint32_t blk)
 	return 0;
 }
 
-static int 
+static int
 schedule_data_read(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 {
 	uint64_t offset;
@@ -1641,7 +1641,7 @@ schedule_data_read(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 
  make_request:
 	req = alloc_vhd_request(s);
-	if (!req) 
+	if (!req)
 		return -EBUSY;
 
 	req->treq  = treq;
@@ -1713,7 +1713,7 @@ schedule_data_write(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 		} else
 			add_to_transaction(&bm->tx, req);
 	} else if (sec == 0 && 	/* first sector inside data block */
-		   s->vhd.footer.type != HD_TYPE_FIXED && 
+		   s->vhd.footer.type != HD_TYPE_FIXED &&
 		   bat_entry(s, blk) != s->first_db &&
 		   test_batmap(s, blk))
 		schedule_redundant_bm_write(s, blk);
@@ -1771,7 +1771,7 @@ schedule_discard(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 	return 0;
 }
 
-static int 
+static int
 schedule_bitmap_read(struct vhd_state *s, uint32_t blk)
 {
 	int err;
@@ -1832,7 +1832,7 @@ schedule_bitmap_write(struct vhd_state *s, uint32_t blk)
 		ASSERT(bat_locked(s) && s->bat.pbw_blk == blk);
 		offset = s->bat.pbw_offset;
 	}
-	
+
 	offset = vhd_sectors_to_bytes(offset);
 
 	req = &bm->req;
@@ -1855,9 +1855,9 @@ schedule_bitmap_write(struct vhd_state *s, uint32_t blk)
 	    req->treq.secs, offset);
 }
 
-/* 
+/*
  * queued requests will be submitted once the bitmap
- * describing them is read and the requests are validated. 
+ * describing them is read and the requests are validated.
  */
 static int
 __vhd_queue_request(struct vhd_state *s, uint8_t op, td_request_t treq)
@@ -2246,7 +2246,7 @@ finish_bitmap_transaction(struct vhd_state *s,
 		if (test_vhd_flag(tx->status, VHD_FLAG_TX_UPDATE_BAT)) {
 			/* still waiting for bat write */
 			ASSERT(bm->blk == s->bat.pbw_blk);
-			ASSERT(test_vhd_flag(s->bat.status, 
+			ASSERT(test_vhd_flag(s->bat.status,
 					     VHD_FLAG_BAT_WRITE_STARTED));
 			s->bat.req.tx = tx;
 			return;
@@ -2371,7 +2371,7 @@ finish_redundant_bm_write(struct vhd_request *req)
 	struct vhd_state *s = (struct vhd_state *) req->state;
 
 	s->returned++;
-	TRACE(s);	
+	TRACE(s);
 	/* blk = req->treq.sec / s->spb;
 	   DBG(TLOG_DBG, "blk: %u\n", blk); */
 
@@ -2415,7 +2415,7 @@ finish_bitmap_read(struct vhd_request *req)
 			next =  r->next;
 			free_vhd_request(s, r);
 
-			ASSERT(tmp.op == VHD_OP_DATA_READ || 
+			ASSERT(tmp.op == VHD_OP_DATA_READ ||
 			       tmp.op == VHD_OP_DATA_WRITE ||
 				   tmp.op == VHD_OP_DISCARD);
 
@@ -2470,7 +2470,7 @@ finish_data_read(struct vhd_request *req)
 {
 	struct vhd_state *s = req->state;
 
-	DBG(TLOG_DBG, "lsec 0x%08"PRIx64", blk: 0x%04"PRIx64"\n", 
+	DBG(TLOG_DBG, "lsec 0x%08"PRIx64", blk: 0x%04"PRIx64"\n",
 	    req->treq.sec, req->treq.sec / s->spb);
 	signal_completion(req, 0);
 }
@@ -2509,7 +2509,7 @@ finish_data_write(struct vhd_request *req)
 
 	} else if (!test_vhd_flag(req->flags, VHD_FLAG_REQ_QUEUED)) {
 		ASSERT(!req->next);
-		DBG(TLOG_DBG, "lsec: 0x%08"PRIx64", blk: 0x%04"PRIx64"\n", 
+		DBG(TLOG_DBG, "lsec: 0x%08"PRIx64", blk: 0x%04"PRIx64"\n",
 		    req->treq.sec, req->treq.sec / s->spb);
 		signal_completion(req, 0);
 	}
@@ -2613,7 +2613,7 @@ vhd_complete(void *arg, struct tiocb *tiocb, int err)
 	}
 }
 
-void 
+void
 vhd_debug(td_driver_t *driver)
 {
 	int i;

--- a/drivers/tapdisk-filter.c
+++ b/drivers/tapdisk-filter.c
@@ -237,6 +237,9 @@ tapdisk_filter_iocbs(struct tfilter *filter, struct iocb **iocbs, int num)
 	for (i = 0; i < num; i++) {
 		struct iocb *io = iocbs[i];
 
+		if (io->aio_lio_opcode == IO_CMD_NOOP)
+			continue;
+
 		if (filter->mode & TD_INJECT_FAULTS) {
 			if ((random() % 100) <= TD_FAULT_RATE) {
 				inject_fault(filter, io);
@@ -259,6 +262,9 @@ tapdisk_filter_events(struct tfilter *filter, struct io_event *events, int num)
 
 	for (i = 0; i < num; i++) {
 		struct iocb *io = events[i].obj;
+
+		if (io->aio_lio_opcode == IO_CMD_NOOP)
+			continue;
 
 		if (filter->mode & TD_INJECT_FAULTS) {
 			if (fault_injected(filter, io)) {

--- a/drivers/tapdisk-filter.c
+++ b/drivers/tapdisk-filter.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -107,7 +107,8 @@ tapdisk_image_check_td_request(td_image_t *image, td_request_t treq)
 	info   = &image->info;
 	rdonly = td_flag_test(image->flags, TD_OPEN_RDONLY);
 
-	if (treq.op != TD_OP_READ && treq.op != TD_OP_WRITE)
+	if (treq.op != TD_OP_READ && treq.op != TD_OP_WRITE &&
+		treq.op != TD_OP_DISCARD)
 		goto fail;
 
 	if (treq.op == TD_OP_WRITE && rdonly) {
@@ -115,7 +116,8 @@ tapdisk_image_check_td_request(td_image_t *image, td_request_t treq)
 		goto fail;
 	}
 
-	if (treq.secs <= 0 || treq.sec + treq.secs > info->size)
+	if ((treq.secs <= 0 || treq.sec + treq.secs > info->size) &&
+		treq.op != TD_OP_DISCARD)
 		goto fail;
 
 	return 0;
@@ -153,6 +155,8 @@ tapdisk_image_check_request(td_image_t *image, td_vbd_request_t *vreq)
 		secs += vreq->iov[i].secs;
 
 	switch (vreq->op) {
+	case TD_OP_DISCARD:
+		/* falls through */
 	case TD_OP_WRITE:
 		if (rdonly) {
 			err = -EPERM;

--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/tapdisk-interface.c
+++ b/drivers/tapdisk-interface.c
@@ -235,6 +235,40 @@ fail:
 }
 
 void
+td_queue_discard(td_image_t *image, td_request_t treq)
+{
+	int err;
+	td_driver_t *driver;
+
+	driver = image->driver;
+	if (!driver) {
+		err = -ENODEV;
+		goto fail;
+	}
+
+	if (!td_flag_test(driver->state, TD_DRIVER_OPEN)) {
+		err = -EBADF;
+		goto fail;
+	}
+
+	if (!driver->ops->td_queue_discard) {
+		err = -EOPNOTSUPP;
+		goto fail;
+	}
+
+	err = tapdisk_image_check_td_request(image, treq);
+	if (err)
+		goto fail;
+
+	driver->ops->td_queue_discard(driver, treq);
+
+	return;
+
+fail:
+	td_complete_request(treq, err);
+}
+
+void
 td_forward_request(td_request_t treq)
 {
 	tapdisk_vbd_forward_request(treq);

--- a/drivers/tapdisk-interface.h
+++ b/drivers/tapdisk-interface.h
@@ -45,6 +45,7 @@ int td_validate_parent(td_image_t *, td_image_t *);
 
 void td_queue_write(td_image_t *, td_request_t);
 void td_queue_read(td_image_t *, td_request_t);
+void td_queue_discard(td_image_t *, td_request_t);
 void td_forward_request(td_request_t);
 void td_complete_request(td_request_t, int);
 

--- a/drivers/tapdisk-queue.c
+++ b/drivers/tapdisk-queue.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -132,12 +132,12 @@ complete_tiocb(struct tqueue *queue, struct tiocb *tiocb, unsigned long res)
 	if (tiocb->op == TIO_CMD_DISCARD) {
 		err = res;
 	} else {
-	if (res == iocb->u.c.nbytes)
-		err = 0;
-	else if ((int)res < 0)
-		err = (int)res;
-	else
-		err = -EIO;
+		if (res == iocb->u.c.nbytes)
+			err = 0;
+		else if ((int)res < 0)
+			err = (int)res;
+		else
+			err = -EIO;
 	}
 	tiocb->cb(tiocb->arg, tiocb, err);
 }
@@ -151,11 +151,11 @@ cancel_tiocbs(struct tqueue *queue, int err)
 	if (!queue->queued)
 		return 0;
 
-	/* 
+	/*
 	 * td_complete may queue more tiocbs, which
 	 * will overwrite the contents of queue->iocbs.
 	 * use a private linked list to keep track
-	 * of the tiocbs we're cancelling. 
+	 * of the tiocbs we're cancelling.
 	 */
 	tiocb  = queue->iocbs[0]->data;
 	queued = queue->queued;
@@ -173,7 +173,7 @@ fail_tiocbs(struct tqueue *queue, int succeeded, int total, int err)
 	ERR(err, "io_submit error: %d of %d failed",
 	    total - succeeded, total);
 
-	/* take any non-submitted, merged iocbs 
+	/* take any non-submitted, merged iocbs
 	 * off of the queue, split them, and fail them */
 	queue->queued = io_expand_iocbs(&queue->opioctx,
 					queue->iocbs, succeeded, total);
@@ -219,7 +219,7 @@ tapdisk_rwio_rw(const struct iocb *iocb)
 	char *buf     = iocb->u.c.buf;
 	long long off = iocb->u.c.offset;
 	size_t size   = iocb->u.c.nbytes;
-	ssize_t (*func)(int, void *, size_t) = 
+	ssize_t (*func)(int, void *, size_t) =
 		(iocb->aio_lio_opcode == IO_CMD_PWRITE ? vwrite : read);
 
 	if (lseek64(fd, off, SEEK_SET) == (off64_t)-1)
@@ -269,7 +269,7 @@ tapdisk_rwio_submit(struct tqueue *queue)
 		if (tiocb->op == TIO_CMD_DISCARD)
 			ep->res = tapdisk_rwio_discard(iocb);
 		else
-		ep->res = tapdisk_rwio_rw(iocb);
+			ep->res = tapdisk_rwio_rw(iocb);
 	}
 
 	split = io_split(&queue->opioctx, rwio->aio_events, merged);
@@ -559,7 +559,7 @@ tapdisk_lio_submit(struct tqueue *queue)
 	queue->queued          = 0;
 
 	if (err)
-		queue->tiocbs_pending -= 
+		queue->tiocbs_pending -=
 			fail_tiocbs(queue, submitted, merged, err);
 
 	return submitted;
@@ -676,7 +676,7 @@ tapdisk_free_queue(struct tqueue *queue)
 	opio_free(&queue->opioctx);
 }
 
-void 
+void
 tapdisk_debug_queue(struct tqueue *queue)
 {
 	struct tiocb *tiocb = queue->deferred.head;

--- a/drivers/tapdisk-queue.h
+++ b/drivers/tapdisk-queue.h
@@ -36,16 +36,19 @@
 #include "io-optimize.h"
 #include "scheduler.h"
 
+#define TIO_CMD_READ    0
+#define TIO_CMD_WRITE   1
+#define TIO_CMD_DISCARD 2
+
 struct tiocb;
 struct tfilter;
 
 typedef void (*td_queue_callback_t)(void *arg, struct tiocb *, int err);
 
-
 struct tiocb {
 	td_queue_callback_t   cb;
 	void                 *arg;
-
+	int                   op;
 	struct iocb           iocb;
 	struct tiocb         *next;
 };

--- a/drivers/tapdisk-queue.h
+++ b/drivers/tapdisk-queue.h
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -72,8 +72,8 @@ struct tqueue {
 	/* number of iocbs pending in the aio layer */
 	int                   iocbs_pending;
 
-	/* number of tiocbs pending in the queue -- 
-	 * this is likely to be larger than iocbs_pending 
+	/* number of tiocbs pending in the queue --
+	 * this is likely to be larger than iocbs_pending
 	 * due to request coalescing */
 	int                   tiocbs_pending;
 

--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -292,7 +292,7 @@ static int
 tapdisk_server_init_aio(void)
 {
 	return tapdisk_init_queue(&server.aio_queue, TAPDISK_TIOCBS,
-				  TIO_DRV_LIO, NULL);
+				  TIO_DRV_RWIO, NULL);
 }
 
 static void
@@ -821,4 +821,3 @@ int
 tapdisk_server_event_set_timeout(event_id_t event_id, struct timeval timeo) {
 	return scheduler_event_set_timeout(&server.scheduler, event_id, timeo);
 }
-

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -426,7 +426,7 @@ tapdisk_vbd_add_secondary(td_vbd_t *vbd)
 
 		vbd->secondary=NULL;
 		vbd->secondary_mode=TD_VBD_SECONDARY_DISABLED;
-		
+
 		goto fail;
 	}
 
@@ -446,7 +446,7 @@ tapdisk_vbd_add_secondary(td_vbd_t *vbd)
 		DPRINTF("In mirror mode\n");
 		vbd->secondary_mode = TD_VBD_SECONDARY_MIRROR;
 		/*
-		 * we actually need this image to also be part of the chain, 
+		 * we actually need this image to also be part of the chain,
 		 * since it may already contain data
 		 */
 		list_add(&second->next, &leaf->next);
@@ -750,7 +750,7 @@ tapdisk_vbd_shutdown(td_vbd_t *vbd)
 	tapdisk_vbd_queue_count(vbd, &new, &pending, &failed, &completed);
 
 	DPRINTF("%s: state: 0x%08x, new: 0x%02x, pending: 0x%02x, "
-		"failed: 0x%02x, completed: 0x%02x\n", 
+		"failed: 0x%02x, completed: 0x%02x\n",
 		vbd->name, vbd->state, new, pending, failed, completed);
 	DPRINTF("last activity: %010ld.%06ld, errors: 0x%04"PRIx64", "
 		"retries: 0x%04"PRIx64", received: 0x%08"PRIx64", "
@@ -777,7 +777,7 @@ tapdisk_vbd_close(td_vbd_t *vbd)
 	if (!list_empty(&vbd->pending_requests))
 		goto fail;
 
-	/* 
+	/*
 	 * if the queue is still active and we have more
 	 * requests, try to complete them before closing.
 	 */
@@ -1144,7 +1144,7 @@ tapdisk_vbd_check_progress(td_vbd_t *vbd)
 }
 
 /*
- * request submission 
+ * request submission
  */
 
 static int
@@ -1371,8 +1371,8 @@ tapdisk_vbd_complete_td_request(td_request_t treq, int res)
 		}
 	}
 
-	if (res != 0 && image->type == DISK_TYPE_NBD && 
-			((image == vbd->secondary) || 
+	if (res != 0 && image->type == DISK_TYPE_NBD &&
+			((image == vbd->secondary) ||
 			 (image == vbd->retired))) {
 		ERROR("Got non-zero res for NBD secondary - disabling "
 				"mirroring: %s",vreq->name);
@@ -1459,12 +1459,12 @@ tapdisk_vbd_issue_request(td_vbd_t *vbd, td_vbd_request_t *vreq)
 			treq.op = TD_OP_WRITE;
                         vbd->vdi_stats.stats->write_reqs_submitted++;
 			/*
-			 * it's important to queue the mirror request before 
-			 * queuing the main one. If the main image runs into 
-			 * ENOSPC, the mirroring could be disabled before 
-			 * td_queue_write returns, so if the mirror request was 
-			 * queued after (which would then not happen), we'd 
-			 * lose that write and cause the process to hang with 
+			 * it's important to queue the mirror request before
+			 * queuing the main one. If the main image runs into
+			 * ENOSPC, the mirroring could be disabled before
+			 * td_queue_write returns, so if the mirror request was
+			 * queued after (which would then not happen), we'd
+			 * lose that write and cause the process to hang with
 			 * unacknowledged writes
 			 */
 			if (vbd->secondary_mode == TD_VBD_SECONDARY_MIRROR)
@@ -1593,7 +1593,7 @@ tapdisk_vbd_reissue_failed_requests(td_vbd_t *vbd)
 		if (vreq->op == TD_OP_DISCARD)
 			err = tapdisk_vbd_issue_request_discard(vbd, vreq);
 		else
-		err = tapdisk_vbd_issue_request(vbd, vreq);
+			err = tapdisk_vbd_issue_request(vbd, vreq);
 		/*
 		 * if this request failed, but was not completed,
 		 * we'll back off for a while.
@@ -1627,7 +1627,7 @@ tapdisk_vbd_issue_new_requests(td_vbd_t *vbd)
 		if (vreq->op == TD_OP_DISCARD)
 			err = tapdisk_vbd_issue_request_discard(vbd, vreq);
 		else
-		err = tapdisk_vbd_issue_request(vbd, vreq);
+			err = tapdisk_vbd_issue_request(vbd, vreq);
 		/*
 		 * if this request failed, but was not completed,
 		 * we'll back off for a while.

--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -62,6 +62,7 @@
 
 #include <time.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "list.h"
 #include "compiler.h"
@@ -74,7 +75,7 @@ extern unsigned int PAGE_MASK;
 extern unsigned int PAGE_SHIFT;
 
 #define MAX_SEGMENTS_PER_REQ         11
-#define MAX_REQUESTS                 32U
+#define MAX_REQUESTS                 128U
 #define SECTOR_SHIFT                 9
 #define DEFAULT_SECTOR_SIZE          512
 
@@ -87,6 +88,7 @@ extern unsigned int PAGE_SHIFT;
 
 #define TD_OP_READ                   0
 #define TD_OP_WRITE                  1
+#define TD_OP_DISCARD                2
 
 #define TD_OPEN_QUIET                0x00001
 #define TD_OPEN_QUERY                0x00002
@@ -138,6 +140,7 @@ struct td_disk_info {
 	td_sector_t                  size;
 	long                         sector_size;
 	uint32_t                     info;
+	bool                         discard;
 };
 
 struct td_iovec {
@@ -148,6 +151,8 @@ struct td_iovec {
 struct td_vbd_request {
 	int                         op;
 	td_sector_t                 sec;
+	uint64_t                    nr_sectors;
+
 	struct td_iovec            *iov;
 	int                         iovcnt;
 
@@ -199,6 +204,7 @@ struct tap_disk {
 	int (*td_validate_parent)    (td_driver_t *, td_driver_t *, td_flag_t);
 	void (*td_queue_read)        (td_driver_t *, td_request_t);
 	void (*td_queue_write)       (td_driver_t *, td_request_t);
+	void (*td_queue_discard)     (td_driver_t *, td_request_t);
 	void (*td_debug)             (td_driver_t *);
 	void (*td_stats)             (td_driver_t *, td_stats_t *);
 

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -125,6 +125,7 @@ struct td_xenblkif {
      */
     int n_reqs_free;
 
+
     blkif_request_t **reqs_free;
 
     /**

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/td-ctx.c
+++ b/drivers/td-ctx.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -701,7 +701,7 @@ tapdisk_xenblkif_parse_request(struct td_xenblkif * const blkif,
     } else {
         blkif->stats.xenvbd->st_rd_sect += nr_sect;
         blkif->vbd_stats.stats->read_sectors += nr_sect;
-    } 
+    }
 
     /*
      * TODO Isn't this kind of expensive to do for each requests? Why does
@@ -914,8 +914,8 @@ tapdisk_xenblkif_queue_requests(struct td_xenblkif * const blkif,
         }
     }
 
-    /* there is a possibility of blkif getting freed if ring is 
-       dead and current request is the last one, hence adding 
+    /* there is a possibility of blkif getting freed if ring is
+       dead and current request is the last one, hence adding
        this check to avoid seg fault */
 
     if (nr_errors && blkif)

--- a/include/tap-ctl.h
+++ b/include/tap-ctl.h
@@ -193,8 +193,9 @@ int tap_ctl_disconnect_xenblkif(const pid_t pid, const domid_t domid,
  * @param minor
  *
  */
-int tap_ctl_info(pid_t pid, unsigned long long *sectors, unsigned int
-		*sector_size, unsigned int *info, const int minor);
+int tap_ctl_info(pid_t pid, unsigned long long *sectors,
+				 unsigned int *sector_size, unsigned int *info,
+				 bool *discard, const int minor);
 
 /**
  * Parses a type:/path/to/file string, storing the type and path to the output

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -32,6 +32,7 @@
 #define _TAPDISK_MESSAGE_H_
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <sys/types.h>
 
 /*
@@ -81,6 +82,7 @@ struct tapdisk_message_image {
 	uint64_t                         sectors;
 	uint32_t                         sector_size;
 	uint32_t                         info;
+	bool                             discard;
 };
 
 struct tapdisk_message_string {

--- a/include/xen_blkif.h
+++ b/include/xen_blkif.h
@@ -46,6 +46,8 @@ struct blkif_common_response {
 	char dummy;
 };
 
+typedef union blkif_request_common blkif_request_common_t;
+
 /* i386 protocol version */
 #pragma pack(push, 4)
 struct blkif_x86_32_request {
@@ -56,12 +58,21 @@ struct blkif_x86_32_request {
 	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
 	struct blkif_request_segment seg[BLKIF_MAX_SEGMENTS_PER_REQUEST];
 };
+struct blkif_x86_32_request_discard {
+	uint8_t        operation;    /* BLKIF_OP_???                         */
+	uint8_t        flags;        /* BLKIF_DISCARD_SECURE or zero         */
+	blkif_vdev_t   handle;       /* only for read/write requests         */
+	uint64_t       id;           /* private guest value, echoed in resp  */
+	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+	uint64_t       nr_sectors;   /* number of contiguous sectors to discard */
+};
 struct blkif_x86_32_response {
 	uint64_t        id;              /* copied from request */
 	uint8_t         operation;       /* copied from request */
 	int16_t         status;          /* BLKIF_RSP_???       */
 };
 typedef struct blkif_x86_32_request blkif_x86_32_request_t;
+typedef struct blkif_x86_32_request_discard blkif_x86_32_request_discard_t;
 typedef struct blkif_x86_32_response blkif_x86_32_response_t;
 #pragma pack(pop)
 
@@ -74,12 +85,22 @@ struct blkif_x86_64_request {
 	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
 	struct blkif_request_segment seg[BLKIF_MAX_SEGMENTS_PER_REQUEST];
 };
+struct blkif_x86_64_request_discard {
+	uint8_t        operation;    /* BLKIF_OP_???                         */
+	uint8_t        flags;        /* BLKIF_DISCARD_SECURE or zero         */
+	blkif_vdev_t   handle;       /* only for read/write requests         */
+	uint32_t       pad;
+	uint64_t       id;           /* private guest value, echoed in resp  */
+	blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+	uint64_t       nr_sectors;   /* number of contiguous sectors to discard */
+};
 struct blkif_x86_64_response {
 	uint64_t       __attribute__((__aligned__(8))) id;
 	uint8_t         operation;       /* copied from request */
 	int16_t         status;          /* BLKIF_RSP_???       */
 };
 typedef struct blkif_x86_64_request blkif_x86_64_request_t;
+typedef struct blkif_x86_64_request_discard blkif_x86_64_request_discard_t;
 typedef struct blkif_x86_64_response blkif_x86_64_response_t;
 
 DEFINE_RING_TYPES(blkif_common, struct blkif_common_request, struct blkif_common_response);
@@ -130,4 +151,24 @@ static inline void blkif_get_x86_64_req(blkif_request_t *dst, blkif_x86_64_reque
 		dst->seg[i] = src->seg[i];
 }
 
+static inline void
+blkif_get_x86_32_req_discard(blkif_request_discard_t *dst,
+							 blkif_x86_32_request_discard_t *src)
+{
+	dst->operation = src->operation;
+	dst->nr_sectors = src->nr_sectors;
+	dst->handle = src->handle;
+	dst->id = src->id;
+	dst->sector_number = src->sector_number;
+}
+
+static inline void blkif_get_x86_64_req_discard(blkif_request_discard_t *dst,
+												blkif_x86_64_request_discard_t *src)
+{
+	dst->operation = src->operation;
+	dst->nr_sectors = src->nr_sectors;
+	dst->handle = src->handle;
+	dst->id = src->id;
+	dst->sector_number = src->sector_number;
+}
 #endif /* __XEN_BLKIF_H__ */

--- a/include/xen_blkif.h
+++ b/include/xen_blkif.h
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -357,7 +357,7 @@ physical_device_changed(vbd_t *device) {
      * get the VBD parameters from the tapdisk
      */
     if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
-                    &device->sector_size, &info,
+							&device->sector_size, &info,
 							&device->discard, device->minor))) {
         WARN(device, "error retrieving disk characteristics: %s\n",
                 strerror(-err));

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -358,7 +358,7 @@ physical_device_changed(vbd_t *device) {
      */
     if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
                     &device->sector_size, &info,
-                    device->minor))) {
+							&device->discard, device->minor))) {
         WARN(device, "error retrieving disk characteristics: %s\n",
                 strerror(-err));
         goto out;

--- a/tapback/frontend.c
+++ b/tapback/frontend.c
@@ -300,6 +300,32 @@ connect_frontend(vbd_t *device) {
             break;
         }
 
+		if (device->backend->discard &&
+			device->mode == true &&
+			device->cdrom == false) {
+
+		    if ((err = tapback_device_printf(device, xst, "discard-granularity",
+											 true, "%u", device->sector_size))) {
+				WARN(device, "failed to write discard-granularity: %s\n",
+					 strerror(-err));
+				break;
+			}
+
+			if ((err = tapback_device_printf(device, xst, "discard-alignment",
+											 true, "%u", 0))) {
+				WARN(device, "failed to write discard-alignment: %s\n",
+					 strerror(-err));
+				break;
+			}
+
+			if ((err = tapback_device_printf(device, xst, "feature-discard",
+											 true, "%u", 1))) {
+				WARN(device, "failed to write feature-discard: %s\n",
+					 strerror(-err));
+				break;
+			}
+		}
+
         if ((err = tapback_device_printf(device, xst, "sector-size", true,
                         "%u", device->sector_size))) {
             WARN(device, "failed to write sector-size: %s\n", strerror(-err));

--- a/tapback/tapback.c
+++ b/tapback/tapback.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/tapback/tapback.c
+++ b/tapback/tapback.c
@@ -230,7 +230,7 @@ tapback_write_pid(const char *pidfile)
  */
 static inline backend_t *
 tapback_backend_create(const char *name, const char *pidfile,
-        const domid_t domid, const bool barrier)
+		const domid_t domid, const bool barrier, const bool discard)
 {
     int err;
     int len;
@@ -268,6 +268,8 @@ tapback_backend_create(const char *name, const char *pidfile,
 	backend->barrier = barrier;
 
     backend->path = NULL;
+
+	backend->discard = discard;
 
     INIT_LIST_HEAD(&backend->entry);
 
@@ -586,6 +588,7 @@ int main(int argc, char **argv)
 	backend_t *backend = NULL;
     domid_t opt_domid = 0;
 	bool opt_barrier = true;
+	bool opt_discard = true;
 
 	if (access("/dev/xen/gntdev", F_OK ) == -1) {
 		WARN(NULL, "grant device does not exist\n");
@@ -613,11 +616,12 @@ int main(int argc, char **argv)
             {"pidfile", 0, NULL, 'p'},
             {"domain", 0, NULL, 'x'},
 			{"nobarrier", 0, NULL, 'b'},
+			{"nodiscard", 0, NULL, 's'},
 
         };
         int c;
 
-        c = getopt_long(argc, argv, "hdvn:p:x:b", longopts, NULL);
+        c = getopt_long(argc, argv, "hdvn:p:x:b:s", longopts, NULL);
         if (c < 0)
             break;
 
@@ -657,6 +661,8 @@ int main(int argc, char **argv)
 		case 'b':
 			opt_barrier = false;
 			break;
+		case 's':
+			opt_discard = false;
         case '?':
             goto usage;
         }
@@ -691,7 +697,7 @@ int main(int argc, char **argv)
     }
 
 	backend = tapback_backend_create(opt_name, opt_pidfile, opt_domid,
-			opt_barrier);
+									 opt_barrier, opt_discard);
 	if (!backend) {
 		err = errno;
         WARN(NULL, "error creating back-end: %s\n", strerror(err));

--- a/tapback/tapback.h
+++ b/tapback/tapback.h
@@ -208,6 +208,11 @@ typedef struct backend {
 	 * Tells whether we support write I/O barriers.
 	 */
 	bool barrier;
+
+	/**
+	 * Tells whether we support discard.
+	 */
+	bool discard;
 } backend_t;
 
 /**
@@ -283,6 +288,11 @@ typedef struct vbd {
      * Number of sectors, supplied by the tapdisk, communicated to blkfront.
      */
     unsigned long long sectors;
+
+	/**
+	 * Whether the backing driver supports discard
+	 */
+	bool discard;
 
     /**
      * VDISK_???, defined in include/xen/interface/io/blkif.h.


### PR DESCRIPTION
Discard is enabled when the frontend sets feature-discard to 1, the discard-granularity to the device sector size, and the discard-alignment to 0. These values will be written to the xenstore.

Discard is enabled if the following conditions are true:

1.    The device backend supports discard
2.    the device is writable
3.    the device is not a cdrom

How tapdisk handles discard requests:

1.   Requests are pulled off the ring from xenio_blkif_get_request(). Depending on the protocol, 
      the discard request will be converted into a blkif_request_discard.
3.   The request is then converted to a td_vbd_request via tapdisk_xenblkif_make_vbd_request()   
      and the vbd request is queued using tapdisk_vbd_queue_request()
3.   tapdisk_vbd_recheck_state() sees the discard request waiting to be issued. 
4.   tapdisk_vbd_issue_request_discard() packages the vbd request into a td_request 
5.   The request will then be handed off to the block driver to queue the request.

The portion of my patch explained above is a slightly modified version of a previous PR https://github.com/xapi-project/blktap/pull/167/commits/1a51656213d5c7184dbcbfc690e9c7ee026ee96d. Credit goes to Rober Breker for implementing a lot of the discard request handling for tapdisk.


How the vhd block driver handles discard requests:

1.   vhd_queue_discard() receives the request.
2.   The request will be separated into smaller requests where the sectors to be discard would
       be equal to the block length.
3.   The smaller requests will be queued in preallocated request array.
4.   tapdisk_rwio_discard() pulls requests off of the request array and fallocate() is called to 
      deallocate the block.

I had to change the tapdisk-queue driver from using LIO to RWIO because currently linux AIO does not support discard requests. This change causes a 50% sequential write degradation. I've attempted to remedy this by using LIO when there are no discard requests on the queue and revert back to RWIO when a discard is queued. Sadly, the IO scheduler doesn't like when you mix LIO and RWIO.

Are there any other approaches I could take? Is discard request support something you guys are interested in having?