### PR TITLE
CA-299175: Deal with events on non-existent paths

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -705,6 +705,18 @@ tapback_backend_probe_device(backend_t *backend,
     remove = device && !should_exist;
     create = !device && should_exist;
 
+	/*
+	 * Sometimes we can get asked to process a notification for a device which
+	 * we would have been creating, but everything was removed from xenstore
+	 * before we got the notification. Catch this case before it confuses the
+	 * rest of the logic.
+	 */
+	if (!(remove || create)) {
+		WARN(NULL, "Neither remove nor create for domid %d, devname %s\n",
+				domid, devname);
+		return -EINVAL;
+	}
+
     /*
      * Remember that remove and create may both be true at the same time, as
      * this indicates that the device has been removed and re-created too fast.


### PR DESCRIPTION
In rare cases tapback is asked to process a watch where the path in
xenstore has been deleted before the first notification. In this case
the logic could get confused and run on to call frontend() with a NULL
argument, causing frontend() to assert().

tapback_backend_probe_device() is documented to either create or remove
a device. If it finds itself doing neither, simply warn and return an
error.