### PR TITLE
CA-304648: add guard asserts to prevent overwriting the header

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -1754,6 +1754,7 @@ schedule_data_write(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 	}
 
 	blk    = treq.sec / s->spb;
+	ASSERT(blk < s->bat.bat.entries);
 	sec    = treq.sec % s->spb;
 	offset = bat_entry(s, blk);
 
@@ -1771,6 +1772,9 @@ schedule_data_write(struct vhd_state *s, td_request_t treq, vhd_flag_t flags)
 
 	offset += s->bm_secs + sec;
 	offset  = vhd_sectors_to_bytes(offset);
+
+	/* Make sure were not about to overwrite the header */
+	ASSERT(offset >= 1536);
 
  make_request:
 	if (vhd_is_encrypted(s)) {

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -1116,13 +1116,14 @@ vhd_read_bat(vhd_context_t *ctx, vhd_bat_t *bat)
 	/* The BAT size is stored in ctx->header.max_bat_size. However, we
 	 * sometimes preallocate BAT + batmap for max VHD size, so only read in
 	 * the BAT entries that are in use for curr_size */
-	vhd_blks = ctx->footer.curr_size >> VHD_BLOCK_SHIFT;
+	vhd_blks = (ctx->footer.curr_size + ((1 << VHD_BLOCK_SHIFT) - 1)) >> VHD_BLOCK_SHIFT;
+	VHDLOG("Calculated entries for size %lu is %u", ctx->footer.curr_size, vhd_blks);
 	if (ctx->header.max_bat_size < vhd_blks) {
-        VHDLOG("more VHD blocks (%u) than possible (%u)\n",
-                vhd_blks, ctx->header.max_bat_size);
-        err = -EINVAL;
-        goto fail;
-    }
+		VHDLOG("more VHD blocks (%u) than possible (%u)\n",
+		       vhd_blks, ctx->header.max_bat_size);
+		err = -EINVAL;
+		goto fail;
+	}
 	size = vhd_bytes_padded(vhd_blks * sizeof(uint32_t));
 
 	err  = posix_memalign(&buf, VHD_SECTOR_SIZE, size);


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>