### PR TITLE
CA-304562 Stats use-after-free

### DIFF
--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -81,6 +81,13 @@ tapdisk_xenblkif_stats_destroy(struct td_xenblkif *blkif)
     free(blkif->xenvbd_stats.io_ring.path);
     blkif->xenvbd_stats.io_ring.path = NULL;
 
+	/*
+	 * blkif->stats.xenvbd was initialised to blkif->xenvbd_stats.stats.mem
+	 * in tapdisk_xenblkif_stats_create(). That address will be unmapped
+	 * by the call to shm_destroy(), and an error return does not mean it
+	 * wasn't, so we must unconditionally NULL blkif->stats.xenvbd here.
+	 */
+	blkif->stats.xenvbd = NULL;
     err = shm_destroy(&blkif->xenvbd_stats.stats);
     if (unlikely(err))
         goto out;


### PR DESCRIPTION
It is possible for attempts to be made to access through
blkif->stats.xenvbd after the memory it points to has been unmapped by
calling tapdisk_xenblkif_stats_destroy().

NULL the pointer as the memory is unmapped and check it before each
use. If tapdisk_xenblkif_stats_destroy() has been called, we shouldn't
be interested in those updates any more anyway.