### PR TITLE
CA-305951: change xattr_get to tolerate ENOTSUP error

### DIFF
--- a/vhd/lib/xattr.c
+++ b/vhd/lib/xattr.c
@@ -91,7 +91,7 @@ int
 xattr_get(int fd, const char *name, void *value, size_t size)
 {
 	if (_fgetxattr(fd, name, value, size) == -1) {
-		if (errno == ENOATTR) {
+		if ((errno == ENOATTR) || (errno == ENOTSUP)) {
 			memset(value, 0, size);
 			return 0;
 		}


### PR DESCRIPTION
vhd_get_keyhash in libvhd.c uses xattr to retrieve a keyhash when the vhd does not have a batmap.
Since extended attributes is not supported for NFS SRs, using xattr_get in NFS SRs would previously cause a failure when trying to obtain the key from the filesystem.
This broke sr-scan when we had VDIs that were created by other tools.
This change handles this failure, so xattr_get returns 0 when extended attributes is not supported and there is no key to retrieve.

Signed-off-by: Elias Calocane <elias.calocane@citrix.com>