### PR TITLE
CA-306397: consider empty string read from xs_read to be equiv to NULL

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -287,6 +287,12 @@ physical_device_changed(vbd_t *device) {
         goto out;
     }
 
+    if (strlen(s) == 0) {
+	    /* empty string is a missing device */
+	    err = -ENOENT;
+	    goto out;
+    }
+
     /*
      * The XenStore key physical-device contains "major:minor" in hex.
      */


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>