### PR TITLE
Blktap performance updates

### DIFF
--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -362,6 +362,8 @@ tapdisk_start_polling(struct td_xenblkif *blkif)
 
         /* Schedule the future 'stop polling' event */
         tapdisk_xenblkif_sched_stoppolling(blkif);
+
+	tapdisk_server_mask_event(tapdisk_xenblkif_evtchn_event_id(blkif), 1);
     }
 }
 
@@ -383,6 +385,8 @@ tapdisk_xenblkif_cb_stoppolling(event_id_t id __attribute__((unused)),
 
         /* Make the 'stop polling' event not fire again */
         tapdisk_xenblkif_unsched_stoppolling(blkif);
+
+	tapdisk_server_mask_event(tapdisk_xenblkif_evtchn_event_id(blkif), 0);
     }
 }
 

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -121,7 +121,7 @@ td_xenblkif_bufcache_free(struct td_xenblkif * const blkif)
 
     while (blkif->n_reqs_bufcache_free > TD_REQS_BUFCACHE_MIN){
         munmap(blkif->reqs_bufcache[--blkif->n_reqs_bufcache_free],
-               BLKIF_MAX_SEGMENTS_PER_REQUEST << XC_PAGE_SHIFT);
+               BLKIF_MMAX_SEGMENTS_PER_REQUEST << XC_PAGE_SHIFT);
     }
 }
 
@@ -138,7 +138,7 @@ td_xenblkif_bufcache_get(struct td_xenblkif * const blkif)
     ASSERT(blkif);
 
     if (!blkif->n_reqs_bufcache_free) {
-        buf = mmap(NULL, BLKIF_MAX_SEGMENTS_PER_REQUEST << XC_PAGE_SHIFT,
+        buf = mmap(NULL, BLKIF_MMAX_SEGMENTS_PER_REQUEST << XC_PAGE_SHIFT,
                    PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         if (unlikely(buf == MAP_FAILED))
             buf = NULL;
@@ -780,7 +780,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
      */
     if (unlikely((tapreq->msg.nr_segments == 0 &&
                 tapreq->msg.operation != BLKIF_OP_WRITE_BARRIER) ||
-            tapreq->msg.nr_segments > BLKIF_MAX_SEGMENTS_PER_REQUEST)) {
+            tapreq->msg.nr_segments > BLKIF_MMAX_SEGMENTS_PER_REQUEST)) {
         RING_ERR(blkif, "req %lu: bad number of segments in request (%d)\n",
                 tapreq->msg.id, tapreq->msg.nr_segments);
         err = EINVAL;

--- a/drivers/td-req.h
+++ b/drivers/td-req.h
@@ -77,9 +77,9 @@ struct td_xenblkif_req {
     /**
      * The scatter/gather list td_vbd_request_t.iov points to.
      */
-    struct td_iovec iov[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+    struct td_iovec iov[BLKIF_MMAX_SEGMENTS_PER_REQUEST];
 
-    grant_ref_t gref[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+    grant_ref_t gref[BLKIF_MMAX_SEGMENTS_PER_REQUEST];
     int prot;
 
 	struct gntdev_grant_copy_segment

--- a/include/blktaplib.h
+++ b/include/blktaplib.h
@@ -227,10 +227,10 @@ typedef struct msg_lock {
 
 /* Accessing attached data page mappings */
 #define MMAP_PAGES                                                    \
-    (MAX_PENDING_REQS * BLKIF_MAX_SEGMENTS_PER_REQUEST)
+    (MAX_PENDING_REQS * BLKIF_MMAX_SEGMENTS_PER_REQUEST)
 #define MMAP_VADDR(_vstart,_req,_seg)                                 \
     ((_vstart) +                                                      \
-     ((_req) * BLKIF_MAX_SEGMENTS_PER_REQUEST * getpagesize()) +      \
+     ((_req) * BLKIF_MMAX_SEGMENTS_PER_REQUEST * getpagesize()) +      \
      ((_seg) * getpagesize()))
 
 /* Defines that are only used by library clients */

--- a/include/xen_blkif.h
+++ b/include/xen_blkif.h
@@ -130,4 +130,9 @@ static inline void blkif_get_x86_64_req(blkif_request_t *dst, blkif_x86_64_reque
 		dst->seg[i] = src->seg[i];
 }
 
+#define MAX_RING_PAGE_ORDER 3
+#define MAX_RING_PAGES (1 << MAX_RING_PAGE_ORDER)
+
+#define BLKIF_MMAX_SEGMENTS_PER_REQUEST 32
+
 #endif /* __XEN_BLKIF_H__ */

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
+#include "xen_blkif.h"
 
 extern int tapdev_major;
 
@@ -215,6 +216,15 @@ tapback_backend_create_device(backend_t *backend,
 
     if (!(device->name = strdup(name))) {
         err = -errno;
+        goto out;
+    }
+
+    /* Enable multi-page rings */
+    err = tapback_device_printf(device, XBT_NULL, "max-ring-page-order",
+                                true, "%d", MAX_RING_PAGE_ORDER);
+    if (unlikely(err)) {
+        WARN(device, "failed to write max-ring-page-order: %s\n",
+             strerror(-err));
         goto out;
     }
 


### PR DESCRIPTION
* Enable multipage ring support in blktap
* When in polling mode, mask the event channel events to reduce system call overhead.