### PR TITLE
LIBBLOCKCRYPTO_NAME consolidation & versioning

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -79,8 +79,6 @@
 
 unsigned int SPB;
 
-#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
-
 #define DEBUGGING   2
 #define MICROSOFT_COMPAT
 

--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -86,6 +86,7 @@
 #define vhd_flag_clear(word, flag)       ((word) &= ~(flag))
 #define vhd_flag_test(word, flag)        ((word) & (flag))
 
+#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
 
 #define CRYPTO_DEFAULT_KEYDIR "/var/xen/blktap/keys"
 extern int CRYPTO_SUPPORTED_KEYSIZE[];

--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -86,7 +86,7 @@
 #define vhd_flag_clear(word, flag)       ((word) &= ~(flag))
 #define vhd_flag_test(word, flag)        ((word) & (flag))
 
-#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
+#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so.0"
 
 #define CRYPTO_DEFAULT_KEYDIR "/var/xen/blktap/keys"
 extern int CRYPTO_SUPPORTED_KEYSIZE[];

--- a/vhd/lib/vhd-util-copy.c
+++ b/vhd/lib/vhd-util-copy.c
@@ -46,8 +46,6 @@
 
 #include "libvhd.h"
 
-#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
-
 typedef int (*vhd_calculate_keyhash)(struct vhd_keyhash *keyhash,
 					     const uint8_t *key, size_t key_byte);
 typedef int (*vhd_open_crypto)(vhd_context_t *, const uint8_t *, size_t,

--- a/vhd/lib/vhd-util-key.c
+++ b/vhd/lib/vhd-util-key.c
@@ -39,8 +39,6 @@
 
 #include "libvhd.h"
 
-#define LIBBLOCKCRYPTO_NAME "libblockcrypto.so"
-
 #define MAX_KEY_SIZE 512
 int CRYPTO_SUPPORTED_KEYSIZE[] = { 512, 256, -1};
 


### PR DESCRIPTION
This PR consolidates the three definitions of LIBBLOCKCRYPTO_NAME into libvhd.h and adds the major version (.0) to the string.

OpenXT doesn't install a `libblockcrypto.so` symlink, only `libblockcrypto.so.0` as a symlink to `libblockcrypto.so.0.0.0`.  This leads to a runtime failure when dlopen can't find the library - "failed to load crypto support library".  It's more defensive to specify the major version.  That way a major version change will result in an error instead of being used when there can be incompatible changes.

`libblockcrypto.so` should already be a symlink to `libblockcrypto.so.0.0.0` anyway, so there should be no functional change.  I've tested this on OpenXT, but not XenServer.  On an existing XenServer system, you can verify the `libblockcrypto.so.0` is present to avoid this PR breaking blktap.