### PR TITLE
CA-327558: avoid io_getevents syscall and fadvise

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -39,6 +39,7 @@ blktap/
    |-- driver/
    |      |-- atomicio.c
    |      |-- atomicio.h
+   |      |-- aio_getevents.c
    |      |-- md5.c
    |      |-- md5.h
    |

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -81,6 +81,7 @@ libtapdisk_la_SOURCES += ../cpumond/cpumond.h
 libtapdisk_la_SOURCES += log.h
 
 libtapdisk_la_SOURCES += block-aio.c
+libtapdisk_la_SOURCES += aio_getevents.c
 libtapdisk_la_SOURCES += block-aio.h
 libtapdisk_la_SOURCES += block-ram.c
 libtapdisk_la_SOURCES += block-cache.c

--- a/drivers/aio_getevents.c
+++ b/drivers/aio_getevents.c
@@ -1,0 +1,115 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "aio_getevents.h"
+#include "spdk/stdinc.h"
+#include "spdk/barrier.h"
+#include "spdk/likely.h"
+#include "spdk/util.h"
+
+/* For user space reaping of completions */
+struct spdk_aio_ring {
+	uint32_t id;
+	uint32_t size;
+	uint32_t head;
+	uint32_t tail;
+
+	uint32_t version;
+	uint32_t compat_features;
+	uint32_t incompat_features;
+	uint32_t header_length;
+};
+
+#define SPDK_AIO_RING_VERSION	0xa10a10a1
+
+int user_io_getevents(io_context_t io_ctx, unsigned int max, struct io_event *uevents)
+{
+	uint32_t head, tail, count;
+	struct spdk_aio_ring *ring;
+	struct timespec timeout;
+	struct io_event *kevents;
+
+	ring = (struct spdk_aio_ring *)io_ctx;
+
+	if (spdk_unlikely(ring->version != SPDK_AIO_RING_VERSION || ring->incompat_features != 0)) {
+		timeout.tv_sec = 0;
+		timeout.tv_nsec = 0;
+
+		return io_getevents(io_ctx, 0, max, uevents, &timeout);
+	}
+
+	/* Read the current state out of the ring */
+	head = ring->head;
+	tail = ring->tail;
+
+	/* This memory barrier is required to prevent the loads above
+	 * from being re-ordered with stores to the events array
+	 * potentially occurring on other threads. */
+	spdk_smp_rmb();
+
+	/* Calculate how many items are in the circular ring */
+	count = tail - head;
+	if (tail < head) {
+		count += ring->size;
+	}
+
+	/* Reduce the count to the limit provided by the user */
+	count = spdk_min(max, count);
+
+	/* Grab the memory location of the event array */
+	kevents = (struct io_event *)((uintptr_t)ring + ring->header_length);
+
+	/* Copy the events out of the ring. */
+	if ((head + count) <= ring->size) {
+		/* Only one copy is required */
+		memcpy(uevents, &kevents[head], count * sizeof(struct io_event));
+	} else {
+		uint32_t first_part = ring->size - head;
+		/* Two copies are required */
+		memcpy(uevents, &kevents[head], first_part * sizeof(struct io_event));
+		memcpy(&uevents[first_part], &kevents[0], (count - first_part) * sizeof(struct io_event));
+	}
+
+	/* Update the head pointer. On x86, stores will not be reordered with older loads,
+	 * so the copies out of the event array will always be complete prior to this
+	 * update becoming visible. On other architectures this is not guaranteed, so
+	 * add a barrier. */
+#if defined(__i386__) || defined(__x86_64__)
+	spdk_compiler_barrier();
+#else
+	spdk_smp_mb();
+#endif
+	ring->head = (head + count) % ring->size;
+
+	return count;
+}

--- a/drivers/aio_getevents.h
+++ b/drivers/aio_getevents.h
@@ -1,0 +1,5 @@
+#ifndef _AIO_GETEVENTS_H
+#define _AIO_GETEVENTS_H
+#include <libaio.h>
+int user_io_getevents(io_context_t io_ctx, unsigned int max, struct io_event *uevents);
+#endif

--- a/drivers/tapdisk-queue.c
+++ b/drivers/tapdisk-queue.c
@@ -50,6 +50,7 @@
 
 #include "libaio-compat.h"
 #include "atomicio.h"
+#include "aio_getevents.h"
 
 #define WARN(_f, _a...) tlog_write(TLOG_WARN, _f, ##_a)
 #define DBG(_f, _a...) tlog_write(TLOG_DBG, _f, ##_a)
@@ -460,7 +461,7 @@ tapdisk_lio_event(event_id_t id, char mode, void *private)
 	lio   = queue->tio_data;
 	/* io_getevents() invoked via the libaio wrapper does not set errno but
 	 * instead returns -errno on error */
-	while ((ret = io_getevents(lio->aio_ctx, 0, queue->size, lio->aio_events, NULL)) < 0) {
+	while ((ret = user_io_getevents(lio->aio_ctx, queue->size, lio->aio_events)) < 0) {
 		/* Permit some errors to retry */
 		if (ret == -EINTR) continue;
 		ERR(ret, "io_getevents() non-retryable error");

--- a/include/spdk/barrier.h
+++ b/include/spdk/barrier.h
@@ -1,0 +1,116 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   Copyright (c) 2017, IBM Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \file
+ * Memory barriers
+ */
+
+#ifndef SPDK_BARRIER_H
+#define SPDK_BARRIER_H
+
+#include "spdk/stdinc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Compiler memory barrier */
+#define spdk_compiler_barrier() __asm volatile("" ::: "memory")
+
+/** Read memory barrier */
+#define spdk_rmb()	_spdk_rmb()
+
+/** Write memory barrier */
+#define spdk_wmb()	_spdk_wmb()
+
+/** Full read/write memory barrier */
+#define spdk_mb()	_spdk_mb()
+
+/** SMP read memory barrier. */
+#define spdk_smp_rmb()	_spdk_smp_rmb()
+
+/** SMP write memory barrier. */
+#define spdk_smp_wmb()	_spdk_smp_wmb()
+
+/** SMP read/write memory barrier. */
+#define spdk_smp_mb()	_spdk_smp_mb()
+
+#ifdef __PPC64__
+
+#define _spdk_rmb()	__asm volatile("sync" ::: "memory")
+#define _spdk_wmb()	__asm volatile("sync" ::: "memory")
+#define _spdk_mb()	__asm volatile("sync" ::: "memory")
+#define _spdk_smp_rmb()	__asm volatile("lwsync" ::: "memory")
+#define _spdk_smp_wmb()	__asm volatile("lwsync" ::: "memory")
+#define _spdk_smp_mb()	spdk_mb()
+
+#elif defined(__aarch64__)
+
+#define _spdk_rmb()	__asm volatile("dsb ld" ::: "memory")
+#define _spdk_wmb()	__asm volatile("dsb st" ::: "memory")
+#define _spdk_mb()	__asm volatile("dsb sy" ::: "memory")
+#define _spdk_smp_rmb()	__asm volatile("dmb ishld" ::: "memory")
+#define _spdk_smp_wmb()	__asm volatile("dmb ishst" ::: "memory")
+#define _spdk_smp_mb()	__asm volatile("dmb ish" ::: "memory")
+
+#elif defined(__i386__) || defined(__x86_64__)
+
+#define _spdk_rmb()	__asm volatile("lfence" ::: "memory")
+#define _spdk_wmb()	__asm volatile("sfence" ::: "memory")
+#define _spdk_mb()	__asm volatile("mfence" ::: "memory")
+#define _spdk_smp_rmb()	spdk_compiler_barrier()
+#define _spdk_smp_wmb()	spdk_compiler_barrier()
+#if defined(__x86_64__)
+#define _spdk_smp_mb()	__asm volatile("lock addl $0, -128(%%rsp); " ::: "memory");
+#elif defined(__i386__)
+#define _spdk_smp_mb()	__asm volatile("lock addl $0, -128(%%esp); " ::: "memory");
+#endif
+
+#else
+
+#define _spdk_rmb()
+#define _spdk_wmb()
+#define _spdk_mb()
+#define _spdk_smp_rmb()
+#define _spdk_smp_wmb()
+#define _spdk_smp_mb()
+#error Unknown architecture
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/spdk/likely.h
+++ b/include/spdk/likely.h
@@ -1,0 +1,46 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \file
+ * Likely/unlikely branch prediction macros
+ */
+
+#ifndef SPDK_LIKELY_H
+#define SPDK_LIKELY_H
+
+#include "spdk/stdinc.h"
+
+#define spdk_unlikely(cond)	__builtin_expect((cond), 0)
+#define spdk_likely(cond)	__builtin_expect(!!(cond), 1)
+
+#endif

--- a/include/spdk/stdinc.h
+++ b/include/spdk/stdinc.h
@@ -1,0 +1,97 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \file
+ * Standard C headers
+ *
+ * This file is intended to be included first by all other SPDK files.
+ */
+
+#ifndef SPDK_STDINC_H
+#define SPDK_STDINC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Standard C */
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* POSIX */
+#include <arpa/inet.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <poll.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <syslog.h>
+#include <termios.h>
+#include <unistd.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <regex.h>
+
+/* GNU extension */
+#include <getopt.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPDK_STDINC_H */

--- a/include/spdk/util.h
+++ b/include/spdk/util.h
@@ -1,0 +1,116 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright (c) Intel Corporation. All rights reserved.
+ *   Copyright (c) 2019 Mellanox Technologies LTD. All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \file
+ * General utility functions
+ */
+
+#ifndef SPDK_UTIL_H
+#define SPDK_UTIL_H
+
+#include "spdk/stdinc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define spdk_min(a,b) (((a)<(b))?(a):(b))
+#define spdk_max(a,b) (((a)>(b))?(a):(b))
+
+#define SPDK_COUNTOF(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+#define SPDK_CONTAINEROF(ptr, type, member) ((type *)((uintptr_t)ptr - offsetof(type, member)))
+
+#define SPDK_SEC_TO_USEC 1000000ULL
+#define SPDK_SEC_TO_NSEC 1000000000ULL
+
+/* Ceiling division of unsigned integers */
+#define SPDK_CEIL_DIV(x,y) (((x)+(y)-1)/(y))
+
+uint32_t spdk_u32log2(uint32_t x);
+
+static inline uint32_t
+spdk_align32pow2(uint32_t x)
+{
+	return 1u << (1 + spdk_u32log2(x - 1));
+}
+
+uint64_t spdk_u64log2(uint64_t x);
+
+static inline uint64_t
+spdk_align64pow2(uint64_t x)
+{
+	return 1u << (1 + spdk_u64log2(x - 1));
+}
+
+/**
+ * Check if a uint32_t is a power of 2.
+ */
+static inline bool
+spdk_u32_is_pow2(uint32_t x)
+{
+	if (x == 0) {
+		return false;
+	}
+
+	return (x & (x - 1)) == 0;
+}
+
+static inline uint64_t
+spdk_divide_round_up(uint64_t num, uint64_t divisor)
+{
+	return (num + divisor - 1) / divisor;
+}
+
+
+/**
+ * Scan build is really pessimistic and assumes that mempool functions can
+ * dequeue NULL buffers even if they return success. This is obviously a false
+ * possitive, but the mempool dequeue can be done in a DPDK inline function that
+ * we can't decorate with usual assert(buf != NULL). Instead, we'll
+ * preinitialize the dequeued buffer array with some dummy objects.
+ */
+#define SPDK_CLANG_ANALYZER_PREINIT_PTR_ARRAY(arr, arr_size, buf_size) \
+	do { \
+		static char dummy_buf[buf_size]; \
+		int i; \
+		for (i = 0; i < arr_size; i++) { \
+			arr[i] = (void *)dummy_buf; \
+		} \
+	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -2641,7 +2641,6 @@ vhd_open(vhd_context_t *ctx, const char *file, int flags)
 			goto fail;
 		}
 
-		posix_fadvise(ctx->fd, 0, 0, POSIX_FADV_RANDOM);
 	}
 
 	err = vhd_test_file_fixed(ctx->file, &ctx->is_block);


### PR DESCRIPTION
This can be done entirely in user-space, which is how SPDK, FIO and QEMU does it.

To get the full speed improvements this also requires using `preadv` instead of `pread`, coming up in a separate PR.

A little more information about this can be found here:
https://blog.cloudflare.com/io_submit-the-epoll-alternative-youve-never-heard-about/#gettingridofio_getevents