### PR TITLE
CA-327558: avoid some eventfd reads

### DIFF
--- a/drivers/tapdisk-queue.h
+++ b/drivers/tapdisk-queue.h
@@ -123,4 +123,6 @@ int tapdisk_cancel_all_tiocbs(struct tqueue *);
 void tapdisk_prep_tiocb(struct tiocb *, int, int, char *, size_t,
 			long long, td_queue_callback_t, void *);
 
+void tapdisk_lio_start_polling(struct tqueue *queue);
+void tapdisk_lio_stop_polling(struct tqueue *queue);
 #endif

--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -163,6 +163,18 @@ tapdisk_server_queue_tiocb(struct tiocb *tiocb)
 }
 
 void
+tapdisk_server_start_polling(void)
+{
+    tapdisk_lio_start_polling(&server.aio_queue);
+}
+
+void
+tapdisk_server_stop_polling(void)
+{
+    tapdisk_lio_stop_polling(&server.aio_queue);
+}
+
+void
 tapdisk_server_debug(void)
 {
 	td_vbd_t *vbd, *tmp;

--- a/drivers/tapdisk-server.h
+++ b/drivers/tapdisk-server.h
@@ -84,5 +84,7 @@ void tapdisk_stop_logging(void);
 int tapdisk_server_event_set_timeout(event_id_t, struct timeval timeo);
 
 float tapdisk_server_system_idle_cpu(void);
+void tapdisk_server_start_polling(void);
+void tapdisk_server_stop_polling(void);
 
 #endif

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -364,6 +364,7 @@ tapdisk_start_polling(struct td_xenblkif *blkif)
         tapdisk_xenblkif_sched_stoppolling(blkif);
 
 	tapdisk_server_mask_event(tapdisk_xenblkif_evtchn_event_id(blkif), 1);
+        tapdisk_server_start_polling();
     }
 }
 
@@ -387,6 +388,7 @@ tapdisk_xenblkif_cb_stoppolling(event_id_t id __attribute__((unused)),
         tapdisk_xenblkif_unsched_stoppolling(blkif);
 
 	tapdisk_server_mask_event(tapdisk_xenblkif_evtchn_event_id(blkif), 0);
+        tapdisk_server_stop_polling();
     }
 }
 


### PR DESCRIPTION
When we're polling in user-space this is not needed.
Gives ~4% improvement on bs 2M, iodepth 8.

Also delete obsolete code when eventfd is not available (in our kernels it always is).

Signed-off-by: Edwin Török <edvin.torok@citrix.com>