### PR TITLE
CP-32675 Use the stable Xen interfaces

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -105,7 +105,8 @@ libtapdisk_la_SOURCES += td-stats.h
 
 libtapdisk_la_LIBADD  = ../vhd/lib/libvhd.la
 libtapdisk_la_LIBADD += -laio
-libtapdisk_la_LIBADD += -lxenctrl
+libtapdisk_la_LIBADD += -lxenevtchn
+libtapdisk_la_LIBADD += -lxengnttab
 libtapdisk_la_LIBADD += -lz
 libtapdisk_la_LIBADD += -lrt
 libtapdisk_la_LIBADD += -ldl

--- a/drivers/tapdisk-ring.c
+++ b/drivers/tapdisk-ring.c
@@ -34,6 +34,7 @@
 
 #include <errno.h>
 
+#include "blktap-xenif.h"
 #include "tapdisk-ring.h"
 
 static int

--- a/drivers/tapdisk-ring.h
+++ b/drivers/tapdisk-ring.h
@@ -33,7 +33,6 @@
 
 #include <inttypes.h>
 
-#include <xenctrl.h>
 #include <xen/io/ring.h>
 
 typedef struct td_uring             td_uring_t;

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -31,6 +31,8 @@
 #ifndef __TD_BLKIF_H__
 #define __TD_BLKIF_H__
 
+#include "blktap-xenif.h"
+
 #include <inttypes.h> /* required by xen/event_channel.h */
 
 #include <xen/xen.h>

--- a/drivers/td-ctx.h
+++ b/drivers/td-ctx.h
@@ -31,7 +31,7 @@
 #ifndef __TD_CTX_H__
 #define __TD_CTX_H__
 
-#include <xenctrl.h>
+#include "blktap-xenif.h"
 #include "td-blkif.h"
 #include "scheduler.h"
 
@@ -55,12 +55,12 @@ struct td_xenio_ctx {
     /**
      * Handle to the grant table driver.
      */
-    xc_gnttab *xcg_handle;
+    xengnttab_handle *xcg_handle;
 
     /**
      * Handle to the event channel driver.
      */
-    xc_evtchn *xce_handle;
+    xenevtchn_handle *xce_handle;
 
     /**
      * Return value of tapdisk_server_register_event, we use this to tell

--- a/drivers/td-req.h
+++ b/drivers/td-req.h
@@ -32,6 +32,7 @@
 #define __TD_REQ_H__
 
 #include "tapdisk.h"
+#include "blktap-xenif.h"
 #include <sys/types.h>
 #include <xen/io/blkif.h>
 #include <xen/gntdev.h>
@@ -62,7 +63,7 @@ struct td_xenblkif_req {
 
     /**
      * Pointer to memory-mapped grant refs. We keep this around because we need
-     * to pass it to xc_gnttab_munmap when the requests is completed.
+     * to pass it to xengnttab_munmap when the requests is completed.
      */
     void *vma;
 

--- a/drivers/td-stats.c
+++ b/drivers/td-stats.c
@@ -29,7 +29,6 @@
  */
 
 #include <stdlib.h>
-#include <xenctrl.h>
 
 #include "debug.h"
 #include "tapdisk-log.h"

--- a/include/blktap-xenif.h
+++ b/include/blktap-xenif.h
@@ -1,0 +1,21 @@
+#ifndef __BLKTAPXENIF_H__
+#define __BLKTAPXENIF_H__
+
+/* Make sure that __XEN_INTERFACE_VERSION__ is defined high enough
+ * that xen/io/ring.h will not attempt to define xen_mb() and friends.
+ * This file needs to be included before anything which includes
+ * xen/io/ring.h */
+#define __XEN_INTERFACE_VERSION__ 0x00040000
+
+/* Header files for the stable event channel and grant table
+ * interfaces */
+#include <xenevtchn.h>
+#include <xengnttab.h>
+
+/* Get the correct defines for memory barriers - do not fall
+ * back to those provided by the kernel */
+#define xen_mb()  asm volatile ("mfence" ::: "memory")
+#define xen_rmb() asm volatile ("" ::: "memory")
+#define xen_wmb() asm volatile ("" ::: "memory")
+
+#endif /* __BLKTAPXENIF_H__ */

--- a/include/blktaplib.h
+++ b/include/blktaplib.h
@@ -33,7 +33,6 @@
 
 #include <syslog.h>
 #include <sys/time.h>
-#include <xenctrl.h>
 #include <xen/io/blkif.h>
 
 #ifdef TAPDISK
@@ -47,7 +46,7 @@
 #define PERROR(_f, _a...)  EPRINTF(_f ": %s", ##_a, strerror(errno))
 #endif
 
-#define BLK_RING_SIZE __RING_SIZE((blkif_sring_t *)0, XC_PAGE_SIZE)
+#define BLK_RING_SIZE __RING_SIZE((blkif_sring_t *)0, PAGE_SIZE)
 
 /* size of the extra VMA area to map in attached pages. */
 #define BLKTAP_VMA_PAGES BLK_RING_SIZE

--- a/tests/test_td-ctx.c
+++ b/tests/test_td-ctx.c
@@ -29,7 +29,6 @@
  */
 
 #include "unity.h"
-#include <xenctrl.h>
 #include "drivers/td-ctx.h"
 #include "mock_tapdisk-server.h"
 #include "mock_tapdisk-log.h"

--- a/tests/test_td-req.c
+++ b/tests/test_td-req.c
@@ -32,7 +32,6 @@
 #include "drivers/tapdisk.h"
 #include "mock_tapdisk-stats.h"
 #include "mock_tapdisk-interface.h"
-#include <xenctrl.h>
 #include "drivers/td-req.h"
 #include "drivers/tapdisk-utils.h"
 #include "mock_td-ctx.h"


### PR DESCRIPTION
libxenctl is not a stable interface. Instead of using it, we should use
libxenevtchn and libxengnttab which have stable sonames

Create a new include/blktap-xenif.h for the bits we need for the control
interfaces.

Use PAGE_SIZE rather than XC_PAGE_SIZE

Signed-off-by: Tim Smith <tim.smith@citrix.com>