### PR TITLE
valve: don't print stats in hex literal

### DIFF
--- a/drivers/block-valve.c
+++ b/drivers/block-valve.c
@@ -658,7 +658,7 @@ td_valve_stats(td_driver_t *driver, td_stats_t *st)
 	int n_reqs;
 
 	tapdisk_stats_field(st, "bridge", "d", valve->brname);
-	tapdisk_stats_field(st, "flags", "#x", valve->flags);
+	tapdisk_stats_field(st, "flags", "lu", valve->flags);
 
 	tapdisk_stats_field(st, "cred", "d", valve->cred);
 	tapdisk_stats_field(st, "need", "d", valve->need);


### PR DESCRIPTION
tapdisks stats are finally parsed as JSON, and JSON does not
support hex literal.

Signed-off-by: Robin Lee <robinlee.sysu@gmail.com>