### PR TITLE
feat(vhd-util-scan): '-m' supports style brace expressions and pattern list

### DIFF
--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -929,7 +929,7 @@ iterator_add_volume(struct iterator *itr,
 		}
 	}
 
-	if (err && err != FNM_PATHNAME)
+	if (err && err != FNM_NOMATCH)
 		return err;
 
 	if (!lv)

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -922,7 +922,7 @@ iterator_add_volume(struct iterator *itr,
 			return -EEXIST;
 
 	for (i = 0; i < vg.lv_cnt; i++) {
-		err = fnmatch(parent, vg.lvs[i].name, FNM_PATHNAME);
+		err = fnmatch(parent, vg.lvs[i].name, FNM_PATHNAME | FNM_EXTMATCH);
 		if (err != FNM_NOMATCH) {
 			lv = vg.lvs + i;
 			break;
@@ -1122,7 +1122,7 @@ vhd_util_scan_find_file_targets(int cnt, char **names,
 	memset(&g, 0, sizeof(g));
 
 	if (filter) {
-		int gflags = ((flags & VHD_SCAN_FAST) ? GLOB_NOSORT : 0);
+		int gflags = ((flags & VHD_SCAN_FAST) ? GLOB_NOSORT : 0) | GLOB_BRACE;
 
 		errno = 0;
 		err   = glob(filter, gflags, vhd_util_scan_error, &g);
@@ -1221,7 +1221,8 @@ vhd_util_scan_sort_volumes(struct lv *lvs, int cnt,
 	for (i = 0; i < cnt; i++) {
 		lv  = lvs + i;
 
-		err = fnmatch(filter, lv->name, FNM_PATHNAME);
+		err = fnmatch(filter, lv->name, FNM_PATHNAME | FNM_EXTMATCH);
+
 		if (err) {
 			if (err != FNM_NOMATCH) {
 				EPRINTF("fnmatch failed: '%s', '%s'\n", 


### PR DESCRIPTION
Currently vhd-util supports the wildcard pattern: 
```vhd-util scan -f -m "VHD-*" ...```

I would like to support pattern list to avoid many vhd-util calls like:
```
./vhd/vhd-util scan -f -m "{/dev/VG_XenStorage-f1f91902-e20e-41ee-fac0-5fa4bc71d0cf/VHD-,/root/vhd-backups/}*"
vhd=VHD-53941576-8955-42f6-bb54-98ea972bb639 capacity=53687091200 size=0 hidden=0 parent=none
vhd= d49cd80a-61ef-11ea-bc55-0242ac130003.vhd capacity=53687091200 size=0 hidden=0 parent=none
```

This PR add this functionality without breaking the default vhd-util command line. And it fixes a bad comparison to `FNM_PATHNAME` in another commit.