### PR TITLE
Add unit tests for tap-ctl list

### DIFF
--- a/control/tap-ctl-list.c
+++ b/control/tap-ctl-list.c
@@ -156,7 +156,7 @@ _tap_ctl_find_minors(struct list_head *list)
 			goto fail;
 		}
 
-		n = sscanf(glbuf.gl_pathv[i], BLKTAP2_SYSFS_DIR"/blktap%d", &tl->minor);
+		n = sscanf(glbuf.gl_pathv[i], BLKTAP2_SYSFS_DIR"/blktap!blktap%d", &tl->minor);
 		if (n != 1) {
 			_tap_list_free(tl);
 			continue;

--- a/mockatests/control/Makefile.am
+++ b/mockatests/control/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/control -I../include
 check_PROGRAMS = test-control
 TESTS = test-control
 
-test_control_SOURCES = test-control.c test-tap-ctl-free.c test-tap-ctl-allocate.c test-tap-ctl-close.c control-wrappers.c
+test_control_SOURCES = test-control.c test-tap-ctl-free.c test-tap-ctl-allocate.c test-tap-ctl-close.c test-tap-ctl-list.c control-wrappers.c util.c
 test_control_LDFLAGS = $(top_srcdir)/control/.libs/libblktapctl.a -lcmocka -luuid
 
 test_control_LDFLAGS += ../wrappers/libwrappers.la
@@ -16,5 +16,6 @@ test_control_LDFLAGS += ../wrappers/libwrappers.la
 #test_control_LDFLAGS += -Wl,--wrap=malloc,--wrap=free
 test_control_LDFLAGS += -Wl,--wrap=socket,--wrap=connect,--wrap=read,--wrap=select,--wrap=write,--wrap=fdopen
 test_control_LDFLAGS += -Wl,--wrap=open,--wrap=ioctl,--wrap=close,--wrap=access,--wrap=mkdir,--wrap=flock,--wrap=unlink,--wrap=__xmknod
-test_control_LDFLAGS += -Wl,--wrap=execl,--wrap=waitpid
+#test_control_LDFLAGS += -Wl,--wrap=execl,--wrap=waitpid
+test_control_LDFLAGS += -Wl,--wrap=glob,--wrap=globfree
 test_control_LDFLAGS += -Wl,--wrap=fopen,--wrap=fclose,--wrap=fseek,--wrap=fwrite

--- a/mockatests/control/control-wrappers.c
+++ b/mockatests/control/control-wrappers.c
@@ -344,6 +344,30 @@ __wrap_socket(int domain, int type, int protocol)
 	return result;
 }
 
+int
+__wrap_glob(const char *pattern, int flags,
+	    int (*errfunc) (const char *epath, int eerrno),
+	    glob_t *pglob)
+{
+	check_expected(pattern);
+	int result = mock();
+	if (result == 0)
+	{
+		pglob->gl_pathc = mock();
+		pglob->gl_pathv = (char **)mock();
+	}
+	return result;
+}
+
+void
+__wrap_globfree(glob_t *pglob)
+{
+	if (pglob->gl_pathv) {
+		test_free(*(pglob->gl_pathv));
+	}
+}
+
+
 void enable_control_mocks()
 {
 	enable_mocks = true;

--- a/mockatests/control/control-wrappers.c
+++ b/mockatests/control/control-wrappers.c
@@ -106,18 +106,14 @@ __wrap_close(int fd)
 {
 	int result;
 
-	if (enable_mocks) {
-		check_expected(fd);
-		result = mock();
-		if (result != 0)
-		{
-			errno = result;
-			result = 1;
-		}
-		return result;
+	check_expected(fd);
+	result = mock();
+	if (result != 0)
+	{
+		errno = result;
+		result = 1;
 	}
-
-	return __real_close(fd);
+	return result;
 }
 
 int
@@ -142,35 +138,25 @@ __wrap_access(const char *pathname, int mode)
 }
 
 size_t
-__real_read(int fd, void *buf, size_t count);
-
-size_t
 __wrap_read(int fd, void *buf, size_t count)
 {
 	int result = -1;
 	struct mock_read_params *params;
 
-	if (enable_mocks) {
-		check_expected(fd);
-		params = (struct mock_read_params *)mock();
+	check_expected(fd);
+	params = (struct mock_read_params *)mock();
 
-		if (params->result > 0) {
-			memcpy(buf, params->data, params->result);
-			result = params->result;
-		}
-		else if (params->result < 0) {
-			errno = -params->result;
-			result = -1;
-		}
-
-		return result;
+	if (params->result > 0) {
+		memcpy(buf, params->data, params->result);
+		result = params->result;
+	}
+	else if (params->result < 0) {
+		errno = -params->result;
+		result = -1;
 	}
 
-	return __real_read(fd, buf, count);
+	return result;
 }
-
-size_t
-__real_write(int fd, const void *buf, size_t count);
 
 /*
  * Wrap the write call.
@@ -185,65 +171,47 @@ __wrap_write(int fd, const void *buf, size_t count)
 {
 	int result;
 
-	if (enable_mocks) {
-		check_expected(fd);
-		check_expected(buf);
-		result = mock();
+	check_expected(fd);
+	check_expected(buf);
+	result = mock();
 
-		if (result > (int)count)
-			result = count;
-		else if (result < 0) {
-			errno = -result;
-			result = -1;
-		}
-		return result;
+	if (result > (int)count)
+		result = count;
+	else if (result < 0) {
+		errno = -result;
+		result = -1;
 	}
-
-	return __real_write(fd, buf, count);
+	return result;
 }
-
-int
-__real_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 
 int
 __wrap_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	int result;
-	if (enable_mocks) {
-		check_expected(sockfd);
-		check_expected(addr);
-		result = mock();
-		if (result) {
-			errno = result;
-			result = -1;
-		}
-		return result;
+	check_expected(sockfd);
+	check_expected(addr);
+	result = mock();
+	if (result) {
+		errno = result;
+		result = -1;
 	}
-	return __real_connect(sockfd, addr, addrlen);
+	return result;
 }
-
-int
-__real_select(int nfds, fd_set *readfds, fd_set *writefds,
-	      fd_set *exceptfds, struct timeval *timeout);
 
 int
 __wrap_select(int nfds, fd_set *readfds, fd_set *writefds,
 	      fd_set *exceptfds, struct timeval *timeout)
 {
 	struct mock_select_params *params;
-	if (enable_mocks) {
-		check_expected(timeout);
-		params = (struct mock_select_params *)mock();
-		if (readfds)
-			memcpy(readfds, &params->readfds, sizeof(fd_set));
-		if (writefds)
-			memcpy(writefds, &params->writefds, sizeof(fd_set));
-		if (exceptfds)
-			memcpy(exceptfds, &params->exceptfds, sizeof(fd_set));
-		return params->result;
-	}
-
-	return __real_select(nfds, readfds, writefds, exceptfds, timeout);
+	check_expected(timeout);
+	params = (struct mock_select_params *)mock();
+	if (readfds)
+		memcpy(readfds, &params->readfds, sizeof(fd_set));
+	if (writefds)
+		memcpy(writefds, &params->writefds, sizeof(fd_set));
+	if (exceptfds)
+		memcpy(exceptfds, &params->exceptfds, sizeof(fd_set));
+	return params->result;
 }
 
 int
@@ -266,64 +234,44 @@ __wrap_mkdir(const char *pathname, mode_t mode)
 }
 
 int
-__real_flock(int fd, int operation);
-
-int
 __wrap_flock(int fd, int operation)
 {
 	int result;
-	if (enable_mocks) {
-		check_expected(fd);
-		result = mock();
-		if (result != 0) {
-			errno = result;
-			result = -1;
-		}
-		return result;
+	check_expected(fd);
+	result = mock();
+	if (result != 0) {
+		errno = result;
+		result = -1;
 	}
-	return __real_flock(fd, operation);
+	return result;
 }
-
-int
-__real___xmknod(int ver, const char * path, mode_t mode, dev_t * dev);
 
 int
 __wrap___xmknod(int ver, const char *pathname, mode_t mode, dev_t * dev)
 {
 	int result;
-	if (enable_mocks)
+	check_expected(pathname);
+	result = mock();
+	if (result != 0)
 	{
-		check_expected(pathname);
-		result = mock();
-		if (result != 0)
-		{
-			errno = result;
-			result = -1;
-		}
-		return result;
+		errno = result;
+		result = -1;
 	}
-	return __real___xmknod(ver, pathname, mode, dev);
+	return result;
 }
-
-int
-__real_unlink(const char *pathname);
 
 int
 __wrap_unlink(const char *pathname)
 {
 	int result;
-	if (enable_mocks)
+	check_expected(pathname);
+	result = mock();
+	if (result != 0)
 	{
-		check_expected(pathname);
-		result = mock();
-		if (result != 0)
-		{
-			errno = result;
-			result = -1;
-		}
-		return result;
+		errno = result;
+		result = -1;
 	}
-	return __real_unlink(pathname);
+	return result;
 }
 
 int

--- a/mockatests/control/test-control.c
+++ b/mockatests/control/test-control.c
@@ -61,7 +61,10 @@ int main(void)
 			tap_ctl_close_tests, testSetup, testTeardown) +
 		cmocka_run_group_tests_name(
 			"Free tests",
-			tap_ctl_free_tests, testSetup, testTeardown);
+			tap_ctl_free_tests, testSetup, testTeardown) +
+		cmocka_run_group_tests_name(
+			"List tests",
+			tap_ctl_list_tests, testSetup, testTeardown);
 
 	/* Need to flag that the tests are done so that the fclose mock goes quiescent */
 	disable_mocks();

--- a/mockatests/control/test-suites.h
+++ b/mockatests/control/test-suites.h
@@ -61,6 +61,13 @@ void test_tap_ctl_free_open_fail(void **state);
 void test_tap_ctl_free_success(void **state);
 void test_tap_ctl_free_ioctl_busy(void **state);
 
+/* tap-ctl list tests */
+void test_tap_ctl_list_success_no_results(void **state);
+void test_tap_ctl_list_success_one_minor_no_td(void **state);
+void test_tap_ctl_list_success_one_td_no_minor_no_path(void **state);
+void test_tap_ctl_list_success_one_td_one_minor_no_path(void **state);
+void test_tap_ctl_list_success(void **state);
+
 static const struct CMUnitTest tap_ctl_allocate_tests[] = {
 	cmocka_unit_test(test_tap_ctl_allocate_prep_dir_no_access),
 	cmocka_unit_test(test_tap_ctl_allocate_no_device_info),
@@ -85,6 +92,14 @@ static const struct CMUnitTest tap_ctl_free_tests[] = {
 	cmocka_unit_test(test_tap_ctl_free_open_fail),
 	cmocka_unit_test(test_tap_ctl_free_success),
 	cmocka_unit_test(test_tap_ctl_free_ioctl_busy)
+};
+
+static const struct CMUnitTest tap_ctl_list_tests[] = {
+	cmocka_unit_test(test_tap_ctl_list_success_no_results),
+	cmocka_unit_test(test_tap_ctl_list_success_one_minor_no_td),
+	cmocka_unit_test(test_tap_ctl_list_success_one_td_no_minor_no_path),
+	cmocka_unit_test(test_tap_ctl_list_success_one_td_one_minor_no_path),
+	cmocka_unit_test(test_tap_ctl_list_success)
 };
 
 #endif /* __TEST_SUITES_H__ */

--- a/mockatests/control/test-tap-ctl-close.c
+++ b/mockatests/control/test-tap-ctl-close.c
@@ -42,17 +42,11 @@
 
 #include <wrappers.h>
 #include "control-wrappers.h"
+#include "util.h"
 #include "test-suites.h"
 
 #include "tap-ctl.h"
 #include "blktap2.h"
-
-void initialise_select_params(struct mock_select_params *params)
-{
-	FD_ZERO(&params->readfds);
-	FD_ZERO(&params->writefds);
-	FD_ZERO(&params->exceptfds);
-}
 
 void test_tap_ctl_close_success(void **state)
 {

--- a/mockatests/control/test-tap-ctl-list.c
+++ b/mockatests/control/test-tap-ctl-list.c
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include <string.h>
+#include <sys/types.h>
+
+#include <wrappers.h>
+#include "control-wrappers.h"
+#include "util.h"
+#include "test-suites.h"
+
+#include "tap-ctl.h"
+#include "blktap2.h"
+
+void test_tap_ctl_list_success_no_results(void **state)
+{
+	int err;
+	struct list_head list = LIST_HEAD_INIT(list);
+
+	expect_string(__wrap_glob, pattern, "/sys/class/blktap2/blktap*");
+	will_return(__wrap_glob, GLOB_NOMATCH);
+	expect_string(__wrap_glob, pattern, "/var/run/blktap-control/ctl*");
+	will_return(__wrap_glob, GLOB_NOMATCH);
+
+	err = tap_ctl_list(&list);
+
+	assert_int_equal(0, err);
+	assert_true(list_empty(&list));
+}
+
+
+void test_tap_ctl_list_success_one_minor_no_td(void **state)
+{
+	int err;
+	tap_list_t *entry;
+	struct list_head list = LIST_HEAD_INIT(list);
+
+	char *sys_glob_path = "/sys/class/blktap2/blktap!blktap0";
+	char *sys_glob_data;
+	char **sys_pathv = &sys_glob_data;
+
+	sys_glob_data = test_malloc(strlen(sys_glob_path) + 2);
+	memset(sys_glob_data, 0, strlen(sys_glob_path) + 2);
+	strcpy(sys_glob_data, sys_glob_path);
+
+	expect_string(__wrap_glob, pattern, "/sys/class/blktap2/blktap*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, sys_pathv);
+	expect_string(__wrap_glob, pattern, "/var/run/blktap-control/ctl*");
+	will_return(__wrap_glob, GLOB_NOMATCH);
+
+	/* Call API */
+	err = tap_ctl_list(&list);
+
+	assert_int_equal(0, err);
+	assert_true(list_is_singular(&list));
+
+	tap_list_for_each_entry(entry, &list) {
+		assert_int_equal(0, entry->minor);
+	}
+	tap_ctl_list_free(&list);
+}
+
+void test_tap_ctl_list_success_one_td_no_minor_no_path(void **state)
+{
+	int err;
+	tap_list_t *entry;
+	struct list_head list = LIST_HEAD_INIT(list);
+
+	pid_t test_pid = 1236;
+	int ipc_socket = 7;
+	char *expected_sock_name = "/var/run/blktap-control/ctl1236";
+	tapdisk_message_t write_message;
+	tapdisk_message_t *read_message;
+	struct mock_ipc_params *pid_ipc_params;
+	struct mock_ipc_params *list_ipc_params;
+	char *glob_path = "/var/run/blktap-control/ctl1236";
+	char *glob_data;
+	char **pathv = &glob_data;
+
+	glob_data = test_malloc(strlen(glob_path) + 2);
+	memset(glob_data, 0, strlen(glob_path) + 2);
+	strcpy(glob_data, glob_path);
+
+	expect_string(__wrap_glob, pattern, "/sys/class/blktap2/blktap*");
+	will_return(__wrap_glob, GLOB_NOMATCH);
+	expect_string(__wrap_glob, pattern, "/var/run/blktap-control/ctl*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, pathv);
+
+	/* IPC PID */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_PID;
+
+	read_message = test_malloc(sizeof(*read_message));
+	memset(read_message, 0, sizeof(*read_message));
+	read_message->type = TAPDISK_MESSAGE_PID_RSP;
+	read_message->u.tapdisk_pid = test_pid;
+
+	pid_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 1);
+
+	test_free(read_message);
+
+	/* IPC List */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_LIST;
+	write_message.cookie = -1;
+
+	read_message = test_malloc(sizeof(*read_message) * 2);
+	memset(read_message, 0, sizeof(*read_message) * 2);
+	read_message[0].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[0].u.list.count = 1;
+	read_message[0].u.list.minor = -1;
+	read_message[0].u.list.state = -1;
+	read_message[0].u.list.path[0] = 0;
+	read_message[1].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[1].u.list.count = 0;
+	read_message[1].u.list.minor = -1;
+	read_message[1].u.list.state = -1;
+	read_message[1].u.list.path[0] = 0;
+
+	list_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 2);
+
+	test_free(read_message);
+
+	/* Call API */
+	err = tap_ctl_list(&list);
+
+	assert_int_equal(0, err);
+	assert_true(list_is_singular(&list));
+
+	tap_list_for_each_entry(entry, &list) {
+		assert_int_equal(-1, entry->minor);
+	}
+
+	tap_ctl_list_free(&list);
+
+	free_ipc_params(pid_ipc_params);
+	free_ipc_params(list_ipc_params);
+}
+
+void test_tap_ctl_list_success_one_td_one_minor_no_path(void **state)
+{
+	int err;
+	tap_list_t *entry;
+	struct list_head list = LIST_HEAD_INIT(list);
+
+	pid_t test_pid = 1236;
+	int ipc_socket = 7;
+	char *expected_sock_name = "/var/run/blktap-control/ctl1236";
+	tapdisk_message_t write_message;
+	tapdisk_message_t *read_message;
+	struct mock_ipc_params *pid_ipc_params;
+	struct mock_ipc_params *list_ipc_params;
+	char *sys_glob_path = "/sys/class/blktap2/blktap!blktap0";
+	char *sys_glob_data;
+	char **sys_pathv = &sys_glob_data;
+	char *glob_path = "/var/run/blktap-control/ctl1236";
+	char *glob_data;
+	char **pathv = &glob_data;
+
+	sys_glob_data = test_malloc(strlen(sys_glob_path) + 2);
+	memset(sys_glob_data, 0, strlen(sys_glob_path) + 2);
+	strcpy(sys_glob_data, sys_glob_path);
+
+	glob_data = test_malloc(strlen(glob_path) + 2);
+	memset(glob_data, 0, strlen(glob_path) + 2);
+	strcpy(glob_data, glob_path);
+
+	expect_string(__wrap_glob, pattern, "/sys/class/blktap2/blktap*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, sys_pathv);
+	expect_string(__wrap_glob, pattern, "/var/run/blktap-control/ctl*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, pathv);
+
+	/* IPC PID */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_PID;
+
+	read_message = test_malloc(sizeof(*read_message));
+	memset(read_message, 0, sizeof(*read_message));
+	read_message->type = TAPDISK_MESSAGE_PID_RSP;
+	read_message->u.tapdisk_pid = test_pid;
+
+	pid_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 1);
+
+	test_free(read_message);
+
+	/* IPC List */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_LIST;
+	write_message.cookie = -1;
+
+	read_message = test_malloc(sizeof(*read_message) * 2);
+	memset(read_message, 0, sizeof(*read_message) * 2);
+	read_message[0].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[0].u.list.count = 1;
+	read_message[0].u.list.minor = 0;
+	read_message[0].u.list.state = 0;
+	read_message[0].u.list.path[0] = 0;
+	read_message[1].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[1].u.list.count = 0;
+	read_message[1].u.list.minor = -1;
+	read_message[1].u.list.state = -1;
+	read_message[1].u.list.path[0] = 0;
+
+	list_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 2);
+
+	test_free(read_message);
+
+	/* Call API */
+	err = tap_ctl_list(&list);
+
+	assert_int_equal(0, err);
+	assert_true(list_is_singular(&list));
+
+	tap_list_for_each_entry(entry, &list) {
+		assert_int_equal(0, entry->minor);
+	}
+
+	tap_ctl_list_free(&list);
+
+	free_ipc_params(pid_ipc_params);
+	free_ipc_params(list_ipc_params);
+}
+
+void test_tap_ctl_list_success(void **state)
+{
+	int err;
+	tap_list_t *entry;
+	struct list_head list = LIST_HEAD_INIT(list);
+
+	pid_t test_pid = 1236;
+	int ipc_socket = 7;
+	char *expected_sock_name = "/var/run/blktap-control/ctl1236";
+	tapdisk_message_t write_message;
+	tapdisk_message_t *read_message;
+	struct mock_ipc_params *pid_ipc_params;
+	struct mock_ipc_params *list_ipc_params;
+	char *sys_glob_path = "/sys/class/blktap2/blktap!blktap0";
+	char *sys_glob_data;
+	char **sys_pathv = &sys_glob_data;
+	char *glob_path = "/var/run/blktap-control/ctl1236";
+	char *glob_data;
+	char **pathv = &glob_data;
+	char *vdi_path =
+		"vhd:/dev/VG_XenStorage-a201d430-bc48-fd74-1aeb-292514d9afd6/"
+		"VHD-b1c552a0-e0e6-4156-b6fe-18d7d114c6be";
+
+	sys_glob_data = test_malloc(strlen(sys_glob_path) + 2);
+	memset(sys_glob_data, 0, strlen(sys_glob_path) + 2);
+	strcpy(sys_glob_data, sys_glob_path);
+
+	glob_data = test_malloc(strlen(glob_path) + 2);
+	memset(glob_data, 0, strlen(glob_path) + 2);
+	strcpy(glob_data, glob_path);
+
+	expect_string(__wrap_glob, pattern, "/sys/class/blktap2/blktap*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, sys_pathv);
+	expect_string(__wrap_glob, pattern, "/var/run/blktap-control/ctl*");
+	will_return(__wrap_glob, 0);
+	will_return(__wrap_glob, 1);
+	will_return(__wrap_glob, pathv);
+
+	/* IPC PID */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_PID;
+
+	read_message = test_malloc(sizeof(*read_message));
+	memset(read_message, 0, sizeof(*read_message));
+	read_message->type = TAPDISK_MESSAGE_PID_RSP;
+	read_message->u.tapdisk_pid = test_pid;
+
+	pid_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 1);
+
+	test_free(read_message);
+
+	/* IPC List */
+	memset(&write_message, 0, sizeof(write_message));
+	write_message.type = TAPDISK_MESSAGE_LIST;
+	write_message.cookie = -1;
+
+	read_message = test_malloc(sizeof(*read_message) * 2);
+	memset(read_message, 0, sizeof(*read_message) * 2);
+	read_message[0].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[0].u.list.count = 1;
+	read_message[0].u.list.minor = 0;
+	read_message[0].u.list.state = 0;
+	strcpy(read_message[0].u.list.path, vdi_path);
+	read_message[1].type = TAPDISK_MESSAGE_LIST_RSP;
+	read_message[1].u.list.count = 0;
+	read_message[1].u.list.minor = -1;
+	read_message[1].u.list.state = -1;
+	read_message[1].u.list.path[0] = 0;
+
+	list_ipc_params = setup_ipc(
+		expected_sock_name, ipc_socket,
+		&write_message, read_message, 2);
+
+	test_free(read_message);
+
+	/* Call API */
+	err = tap_ctl_list(&list);
+
+	assert_int_equal(0, err);
+	assert_true(list_is_singular(&list));
+
+	tap_list_for_each_entry(entry, &list) {
+		assert_int_equal(0, entry->minor);
+		assert_string_equal("vhd", entry->type);
+		assert_string_equal(
+			"/dev/VG_XenStorage-a201d430-bc48-fd74-1aeb-292514d9afd6/"
+			"VHD-b1c552a0-e0e6-4156-b6fe-18d7d114c6be", entry->path);
+	}
+
+	tap_ctl_list_free(&list);
+
+	free_ipc_params(pid_ipc_params);
+	free_ipc_params(list_ipc_params);
+}

--- a/mockatests/control/util.c
+++ b/mockatests/control/util.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include <sys/un.h>
+#include <sys/socket.h>
+
+#include "util.h"
+
+struct mock_ipc_params
+{
+	struct mock_select_params write_select_params;
+	tapdisk_message_t write_message;
+	int read_message_count;
+	struct mock_select_params *read_select_params;
+	tapdisk_message_t *read_message;
+	struct mock_read_params *read_params;
+	struct sockaddr_un saddr;
+};
+
+void initialise_select_params(struct mock_select_params *params)
+{
+	FD_ZERO(&params->readfds);
+	FD_ZERO(&params->writefds);
+	FD_ZERO(&params->exceptfds);
+}
+
+struct mock_ipc_params *setup_ipc(char *ipc_socket_name, int ipc_socket_fd,
+				  tapdisk_message_t *write_message,
+				  tapdisk_message_t *read_message,
+				  int read_message_count)
+{
+	struct mock_ipc_params *ipc_params;
+	int id;
+
+	ipc_params = test_malloc(sizeof(struct mock_ipc_params));
+	ipc_params->read_message_count = read_message_count;
+	ipc_params->read_select_params = test_malloc(read_message_count * sizeof(struct mock_select_params));
+	ipc_params->read_message = test_malloc(read_message_count * sizeof(tapdisk_message_t));
+	ipc_params->read_params = test_malloc(read_message_count * sizeof(struct mock_read_params));
+
+	initialise_select_params(&(ipc_params->write_select_params));
+
+	memcpy(&(ipc_params->write_message), write_message, sizeof(tapdisk_message_t));
+
+	memset(&(ipc_params->saddr), 0, sizeof(ipc_params->saddr));
+	ipc_params->saddr.sun_family = AF_UNIX;
+	strcpy(ipc_params->saddr.sun_path, ipc_socket_name);
+
+	expect_value(__wrap_socket, domain, AF_UNIX);
+	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_any(__wrap_socket, protocol);
+	will_return(__wrap_socket, ipc_socket_fd);
+
+	expect_value(__wrap_connect, sockfd, ipc_socket_fd);
+	expect_memory(__wrap_connect, addr,
+		      &(ipc_params->saddr), sizeof(ipc_params->saddr));
+	will_return(__wrap_connect, 0);
+
+	ipc_params->write_select_params.result = 1;
+	FD_SET(ipc_socket_fd, &(ipc_params->write_select_params.writefds));
+	expect_any(__wrap_select, timeout);
+	will_return(__wrap_select, &(ipc_params->write_select_params));
+
+	expect_value(__wrap_write, fd, ipc_socket_fd);
+	expect_memory(__wrap_write, buf,
+		      &(ipc_params->write_message), sizeof(tapdisk_message_t));
+	will_return(__wrap_write, 1024);
+
+	/* Add Read responses */
+	for (id = 0; id < read_message_count; id++) {
+		initialise_select_params(&(ipc_params->read_select_params[id]));
+		ipc_params->read_select_params[id].result = 1;
+		FD_SET(ipc_socket_fd, &(ipc_params->read_select_params[id].readfds));
+		expect_any(__wrap_select, timeout);
+		will_return(__wrap_select, &(ipc_params->read_select_params[id]));
+
+		memcpy(&(ipc_params->read_message[id]),
+		       &(read_message[id]),
+		       sizeof(tapdisk_message_t));
+
+		ipc_params->read_params[id].result = sizeof(*read_message);
+		ipc_params->read_params[id].data = &(ipc_params->read_message[id]);
+		expect_value(__wrap_read, fd, ipc_socket_fd);
+		will_return(__wrap_read, &(ipc_params->read_params[id]));
+	}
+
+	expect_value(__wrap_close, fd, ipc_socket_fd);
+	will_return(__wrap_close, 0);
+
+	return ipc_params;
+}
+
+void free_ipc_params(struct mock_ipc_params *params)
+{
+	test_free(params->read_message);
+	test_free(params->read_select_params);
+	test_free(params->read_params);
+	test_free(params);
+}
+

--- a/mockatests/control/util.h
+++ b/mockatests/control/util.h
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -28,27 +28,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __CONTROL_WRAPPERS_H__
-#define __CONTROL_WRAPPERS_H__
+#include "control-wrappers.h"
+#include "tap-ctl.h"
+#include "blktap2.h"
 
-#include <stdio.h>
-#include <sys/select.h>
-#include <glob.h>
+struct mock_ipc_params;
 
-struct mock_select_params {
-	int result;
-	fd_set readfds;
-	fd_set writefds;
-	fd_set exceptfds;
-};
+void initialise_select_params(struct mock_select_params *params);
 
-struct mock_read_params
-{
-	int result;
-	void * data;
-};
+struct mock_ipc_params *setup_ipc(
+	char *ipc_socket_name, int ipc_socket_fd,
+	tapdisk_message_t *write_message, tapdisk_message_t *read_message,
+	int read_message_count);
 
-void enable_control_mocks();
-void disable_control_mocks();
-
-#endif /* __CONTROL_WRAPPERS_H__ */
+void free_ipc_params(struct mock_ipc_params *params);


### PR DESCRIPTION
Fix regression bug in listing allocated but not attached tapdisk device minor ids, introduced in a kernel patch change in 2014.