### PR TITLE
CA-338080: prevent segfault if stats have been freed

### DIFF
--- a/drivers/tapdisk-metrics.c
+++ b/drivers/tapdisk-metrics.c
@@ -255,6 +255,7 @@ td_metrics_vbd_stop(stats_t *vbd_stats)
 
     free(vbd_stats->shm.path);
     vbd_stats->shm.path = NULL;
+    vbd_stats->stats = NULL;
 
 end:
     return err;

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -754,7 +754,8 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
     case BLKIF_OP_READ:
         if (likely(blkif->stats.xenvbd))
 			blkif->stats.xenvbd->st_rd_req++;
-        blkif->vbd_stats.stats->read_reqs_submitted++;
+	if (likely(blkif->vbd_stats.stats))
+		blkif->vbd_stats.stats->read_reqs_submitted++;
         tapreq->prot = PROT_WRITE;
         vreq->op = TD_OP_READ;
         break;
@@ -762,7 +763,8 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
     case BLKIF_OP_WRITE_BARRIER:
         if (likely(blkif->stats.xenvbd))
 			blkif->stats.xenvbd->st_wr_req++;
-        blkif->vbd_stats.stats->write_reqs_submitted++;
+	if (likely(blkif->vbd_stats.stats))
+		blkif->vbd_stats.stats->write_reqs_submitted++;
         tapreq->prot = PROT_READ;
         vreq->op = TD_OP_WRITE;
         break;


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>