### PR TITLE
CP-33530 - Allow tap to be setup if the physical-device-path is set

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -184,8 +184,8 @@ find_tapdisk_by_pid(const pid_t pid, const int minor, tap_list_t *tap)
 				break;
 			}
 		}
-        	tap_ctl_list_free(&list);
-        } else {
+		tap_ctl_list_free(&list);
+	} else {
 		DBG(NULL, "no tapdisks\n");
 	}
 

--- a/tapback/tapback.h
+++ b/tapback/tapback.h
@@ -105,11 +105,11 @@ int pretty_time(char *buf, unsigned char buf_len);
 /*
  * Pre-defined XenStore path components used for running the XenBus protocol.
  */
-#define XENSTORE_BACKEND			"backend"
-#define PHYS_DEV_KEY                "physical-device"
+#define XENSTORE_BACKEND	"backend"
+#define PHYS_DEV_KEY		"physical-device"
 #define PHYS_DEV_PATH_KEY	"physical-device-path"
-#define HOTPLUG_STATUS_KEY			"hotplug-status"
-#define MODE_KEY					"mode"
+#define HOTPLUG_STATUS_KEY	"hotplug-status"
+#define MODE_KEY		"mode"
 #define POLLING_DURATION	"polling-duration"
 #define POLLING_IDLE_THRESHOLD	"polling-idle-threshold"
 

--- a/tapback/tapback.h
+++ b/tapback/tapback.h
@@ -107,6 +107,7 @@ int pretty_time(char *buf, unsigned char buf_len);
  */
 #define XENSTORE_BACKEND			"backend"
 #define PHYS_DEV_KEY                "physical-device"
+#define PHYS_DEV_PATH_KEY	"physical-device-path"
 #define HOTPLUG_STATUS_KEY			"hotplug-status"
 #define MODE_KEY					"mode"
 #define POLLING_DURATION	"polling-duration"


### PR DESCRIPTION
Making tapback aware of the physical-device-path.

This key will be set going by the block script in xenopsd. I have left the processing of the physical-device key in place, but it will be deleted once the xenopsd code has been added.

This is running through Storage BST (Job id- )

