### PR TITLE
CA-340619 - Propagate error froms from snaphot creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,5 +88,6 @@ mockatests/wrappers/Makefile
 mockatests/cbt/Makefile
 mockatests/drivers/Makefile
 mockatests/control/Makefile
+mockatests/vhd/Makefile
 ])
 AC_OUTPUT

--- a/mockatests/Makefile.am
+++ b/mockatests/Makefile.am
@@ -4,3 +4,4 @@ SUBDIRS  = wrappers
 SUBDIRS += drivers
 SUBDIRS += cbt
 SUBDIRS += control
+SUBDIRS += vhd

--- a/mockatests/vhd/Makefile.am
+++ b/mockatests/vhd/Makefile.am
@@ -1,0 +1,22 @@
+AM_CFLAGS  = -Wall
+AM_CFLAGS += -Werror
+AM_CFLAGS += -fprofile-dir=/tmp/coverage/blktap/mockatests/vhd -fprofile-arcs -ftest-coverage
+AM_CFLAGS += -Og -fno-inline-functions -g
+AM_CFLAGS += -Doff64_t=__off64_t
+
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/cbt -I../include
+
+check_PROGRAMS = test-vhd-util
+TESTS = test-vhd-util
+
+test_vhd_util_SOURCES = test-vhd-util.c test-vhd-util-snapshot.c vhd-wrappers.c
+test_vhd_util_LDFLAGS = $(top_srcdir)/vhd/lib/libvhd.la -lcmocka -luuid
+test_vhd_util_LDFLAGS += -static-libtool-libs
+test_vhd_util_LDFLAGS += -Wl,--wrap=free
+test_vhd_util_LDFLAGS += -Wl,--wrap=canonpath
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_flag_test
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_snapshot
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_open
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_get_keyhash
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_set_keyhash
+test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_close

--- a/mockatests/vhd/test-suites.h
+++ b/mockatests/vhd/test-suites.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __TEST_SUITES_H__
+#define __TEST_SUITES_H__
+
+#include <setjmp.h>
+#include <cmocka.h>
+#include <uuid/uuid.h>
+#include <stdint.h>
+#include <vhd-util.h>
+#include "vhd-wrappers.h"
+
+/* 'vhd-util snapshot' tests */
+void test_vhd_util_snapshot_enospc_from_vhd_snapshot(void **state);
+void test_vhd_util_snapshot_einval_from_vhd_open(void **state);
+void test_vhd_util_snapshot_einval_from_vhd_get_keyhash(void **state);
+void test_vhd_util_snapshot_einval_from_vhd_open_cookie(void **state);
+void test_vhd_util_snapshot_einval_from_vhd_set_keyhash(void **state);
+
+/* Functions under test */
+extern int vhd_util_snapshot(int , char **);
+
+static int setup(void **state) {
+     reset_flags();
+     return 0;
+}
+
+static const struct CMUnitTest vhd_snapshot_tests[] = {
+	cmocka_unit_test(test_vhd_util_snapshot_enospc_from_vhd_snapshot),
+	cmocka_unit_test(test_vhd_util_snapshot_einval_from_vhd_open),
+	cmocka_unit_test(test_vhd_util_snapshot_einval_from_vhd_get_keyhash),
+	cmocka_unit_test_setup(test_vhd_util_snapshot_einval_from_vhd_open_cookie, setup),
+	cmocka_unit_test_setup(test_vhd_util_snapshot_einval_from_vhd_set_keyhash, setup)
+};
+
+#endif /* __TEST_SUITES_H__ */

--- a/mockatests/vhd/test-vhd-util-snapshot.c
+++ b/mockatests/vhd/test-vhd-util-snapshot.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+#include <wrappers.h>
+
+#include "test-suites.h"
+#include "libvhd.h"
+#include "vhd-wrappers.h"
+
+#define ARGS_SIZE 9
+
+char* args[ARGS_SIZE] = {
+		"--debug",
+		"-n",
+		"test1.vhdcache",
+		"-p",
+		"test2.vhdcache",
+		"-S",
+		"71680",
+		"-e",
+		"-m"};
+
+/*
+ * Tests to ensure errors are propagated by vhd-util-snapshot.
+ */
+void test_vhd_util_snapshot_enospc_from_vhd_snapshot(void **state)
+{
+	will_return(__wrap_canonpath, "testing");
+	will_return(__wrap_vhd_snapshot, ENOSPC);
+	expect_any(__wrap_free, in);
+	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	assert_int_equal(get_close_count(), 0);
+	assert_int_equal(res, ENOSPC);
+}
+
+void test_vhd_util_snapshot_einval_from_vhd_open(void **state)
+{
+	will_return(__wrap_canonpath, "testing");
+	will_return(__wrap_vhd_snapshot, 0);
+	will_return(__wrap_vhd_open, EINVAL);
+	expect_any(__wrap_free, in);
+	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	assert_int_equal(get_close_count(), 0);
+	assert_int_equal(res, EINVAL);
+}
+
+void test_vhd_util_snapshot_einval_from_vhd_get_keyhash(void **state)
+{
+	will_return(__wrap_canonpath, "testing");
+	will_return(__wrap_vhd_snapshot, 0);
+	will_return(__wrap_vhd_open, 0);
+	will_return(__wrap_vhd_get_keyhash, EINVAL);
+	will_return(__wrap_vhd_close, 0);
+	expect_any(__wrap_vhd_close, ctx);
+	expect_any(__wrap_free, in);
+	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	assert_int_equal(get_close_count(), 1);
+	assert_int_equal(res, EINVAL);
+}
+
+void test_vhd_util_snapshot_einval_from_vhd_open_cookie(void **state)
+{
+	will_return(__wrap_canonpath, "testing");
+	will_return(__wrap_vhd_snapshot, 0);
+	set_cookie();
+	will_return(__wrap_vhd_get_keyhash, 0);
+	will_return(__wrap_vhd_close, 0);
+	expect_any(__wrap_vhd_close, ctx);
+	int err[] = {0, EINVAL};
+	set_open_errors(2, err);
+	expect_any(__wrap_free, in);
+	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	assert_int_equal(get_close_count(), 1);
+	assert_int_equal(res, EINVAL);
+}
+
+void test_vhd_util_snapshot_einval_from_vhd_set_keyhash(void **state)
+{
+	will_return(__wrap_canonpath, "testing");
+	will_return(__wrap_vhd_snapshot, 0);
+	will_return_always(__wrap_vhd_open, 0);
+	set_cookie();
+	will_return(__wrap_vhd_get_keyhash, 0);
+	will_return_always(__wrap_vhd_close, 0);
+	will_return(__wrap_vhd_set_keyhash, EINVAL);
+	expect_any_count(__wrap_vhd_close, ctx, 2);
+	expect_any(__wrap_free, in);
+	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	assert_int_equal(get_close_count(), 2);
+	assert_int_equal(res, EINVAL);
+}

--- a/mockatests/vhd/test-vhd-util.c
+++ b/mockatests/vhd/test-vhd-util.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <wrappers.h>
+#include "test-suites.h"
+
+int main(void)
+{
+	int result =
+		cmocka_run_group_tests_name("Snapshot tests", vhd_snapshot_tests, NULL, NULL);
+
+	return result;
+}

--- a/mockatests/vhd/vhd-wrappers.c
+++ b/mockatests/vhd/vhd-wrappers.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "libvhd.h"
+#include "vhd-wrappers.h"
+
+static int	cookie = 0;
+static int	close_count = 0;
+static int	*open_return_errs = NULL;
+static int	n_return_errs = 0;
+static int	open_call_count = 0;
+
+void reset_flags()
+{
+	close_count = 0;
+	cookie = 0;
+	open_return_errs = NULL;
+	n_return_errs = 0;
+	open_call_count = 0;
+}
+
+int get_close_count()
+{
+	return close_count;
+}
+
+void set_open_errors(int nerrs, int* errs)
+{
+	open_return_errs = errs;
+	n_return_errs = nerrs;
+}
+
+void set_cookie()
+{
+	cookie = 1;
+}
+
+void __wrap_free(void* in)
+{
+	check_expected(in);
+}
+
+char *__wrap_canonpath(const char *path, char *resolved_path)
+{
+	return (char*)mock();
+}
+
+int __wrap_vhd_snapshot(const char *snapshot, uint64_t bytes, const char *parent,
+			uint64_t mbytes, uint32_t flag)
+{
+	return (int)mock();
+}
+
+int __wrap_vhd_open(vhd_context_t *ctx, const char *file, int flags)
+{
+	int ret;
+	if(open_return_errs) {
+		ret = open_return_errs[open_call_count];
+
+	} else {
+		ret = (int)mock();
+	}
+	open_call_count++;
+	return ret;
+}
+
+int __wrap_vhd_get_keyhash(vhd_context_t *ctx, struct vhd_keyhash* hash)
+{
+	if(cookie) {
+		hash->cookie = 1;
+	}
+	return (int)mock();
+}
+
+int __wrap_vhd_close(vhd_context_t *ctx)
+{
+	check_expected(ctx);
+	close_count++;
+	return (int)mock();
+}
+
+int __wrap_vhd_set_keyhash(vhd_context_t *ctx, struct vhd_keyhash* hash)
+{
+	return (int)mock();
+}

--- a/mockatests/vhd/vhd-wrappers.h
+++ b/mockatests/vhd/vhd-wrappers.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __VHD_WRAPPERS_H__
+#define __VHD_WRAPPERS_H__
+
+void reset_flags();
+int get_close_count();
+void set_cookie();
+void set_open_errors(int, int*);
+void enable_control_mocks();
+void disable_control_mocks();
+
+#endif /* __VHD_WRAPPERS_H__ */

--- a/vhd/lib/vhd-util-snapshot.c
+++ b/vhd/lib/vhd-util-snapshot.c
@@ -223,14 +223,22 @@ vhd_util_snapshot(int argc, char **argv)
 	}
 
 	err = vhd_snapshot(name, size, backing, msize << 20, flags);
+	if(err)
+		goto out;
 
 	/* Set keyhash if it exists in parent */
 	struct vhd_keyhash vhdhash;
 	err = vhd_open(&vhd, backing, VHD_OPEN_RDONLY);
+	if(err)
+		goto out;
 	err = vhd_get_keyhash(&vhd, &vhdhash);
 	vhd_close(&vhd);
+	if(err)
+		goto out;
 	if (vhdhash.cookie == 1){
 		err = vhd_open(&vhd, name, VHD_OPEN_RDWR);
+		if(err)
+			goto out;
 		err = vhd_set_keyhash(&vhd, &vhdhash);
 		vhd_close(&vhd);
 	}


### PR DESCRIPTION
propagating the errors allows SM to fail gracefully.

Waiting for a build to complete and then I can run this through a BST and remove the red label.