### PR TITLE
feat(vhd/canonpath): add support for DRBD resource path

### DIFF
--- a/vhd/lib/canonpath.c
+++ b/vhd/lib/canonpath.c
@@ -32,6 +32,10 @@
 #include "config.h"
 #endif
 
+#ifndef _GNU_SOURCE
+	#define _GNU_SOURCE
+#endif
+
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -41,73 +45,161 @@
 
 #include "canonpath.h"
 
+char *
+normalize_path(const char *path, size_t path_len)
+{
+	size_t res_len = 0;
+
+	const char *ptr = path;
+	const char *end = path + path_len;
+	const char *next;
+
+	char *normalized_path;
+	if (!path_len || *path != '/') {
+		// Relative path.
+		char *wd = get_current_dir_name();
+		if (!wd)
+			return NULL;
+
+		res_len = strlen(wd);
+		if (!(normalized_path = realloc(wd, res_len + path_len + 1))) {
+			free(wd);
+			return NULL;
+		}
+	} else if (!(normalized_path = malloc(path_len + 1)))
+		return NULL;
+
+	for (ptr = path; ptr < end; ptr = next + 1) {
+		size_t len;
+		if (!(next = memchr(ptr, '/', end - ptr)))
+			next = end;
+		len = next - ptr;
+		switch (len) {
+			case 2:
+				if (ptr[0] == '.' && ptr[1] == '.') {
+					const char *slash = memrchr(normalized_path, '/', res_len);
+					if (slash)
+						res_len = slash - normalized_path;
+					continue;
+				}
+				break;
+			case 1:
+				if (ptr[0] == '.')
+					continue;
+				break;
+			case 0:
+				continue;
+		}
+		normalized_path[res_len++] = '/';
+		memcpy(normalized_path + res_len, ptr, len);
+		res_len += len;
+	}
+
+	if (res_len == 0)
+		normalized_path[res_len++] = '/';
+	normalized_path[res_len] = '\0';
+	return normalized_path;
+}
+
 /*
  * Return a path name which should be used resolving parent.
  * This could be different from realpath as realpath follows all symlinks.
  * Function try to get a file name (even if symlink) contained in /dev/mapper.
+ * Symlinks are also kept if a /dev/drbd/by-res/<UUID>/<VOLUME_ID> path is used.
  */
 char *
 canonpath(const char *path, char *resolved_path)
 {
+	static const char dev_path[] = "/dev/";
+	static const size_t dev_len = sizeof(dev_path) - 1;
+
+	static const char dev_mapper_path[] = "/dev/mapper/";
+	static const size_t dev_mapper_len = sizeof(dev_mapper_path) - 1;
+
+	static const char dev_drbd_res_path[] = "/dev/drbd/by-res/";
+	static const size_t dev_drbd_res_len = sizeof(dev_drbd_res_path) - 1;
+
+	static const char dev_drbd_prefix[] = "/dev/drbd";
+	static const size_t dev_drbd_prefix_len = sizeof(dev_drbd_prefix) - 1;
+
 	/* make some cleanup */
-	char canon[PATH_MAX], *p, *dst;
+	char *canon = NULL, *p, *dst;
 	size_t len = strlen(path);
 
 	if (len >= PATH_MAX)
 		goto fallback;
-	memcpy(canon, path, len+1);
 
-	/* "//" -> "/" */
-	while ((p = strstr(canon, "//")) != NULL)
-		memmove(p, p+1, strlen(p+1)+1);
-
-	/* "/./" -> "/" */
-	while ((p = strstr(canon, "/./")) != NULL)
-		memmove(p, p+2, strlen(p+2)+1);
+	if (!(canon = normalize_path(path, len)))
+		return NULL;
 
 	/*
-	 * if path points to a file in /dev/mapper (with no subdirectories)
-	 * return it without following symlinks
+	 * If path points to a file in /dev/mapper (with no subdirectories)
+	 * return it without following symlinks.
 	 */
-	if (strncmp(canon, "/dev/mapper/", 12) == 0 &&
-	    strchr(canon+12, '/') == NULL &&
+	if (strncmp(canon, dev_mapper_path, dev_mapper_len) == 0 &&
+	    strchr(canon + dev_mapper_len, '/') == NULL &&
 	    access(canon, F_OK) == 0) {
 		strcpy(resolved_path, canon);
-		return resolved_path;
+		goto end;
 	}
 
 	/*
-	 * if path is in a subdirectory of dev (possibly a logical volume)
+	 * If path is in a subdirectory of dev (possibly a logical volume)
 	 * try to find a corresponding file in /dev/mapper and return
-	 * if found
+	 * if found. The path can also be a DRBD volume, try to find it in
+	 * /dev/drbd/by-res/.
 	 */
-	if (strncmp(canon, "/dev/", 5) == 0 &&
-	    (p = strchr(canon+5, '/')) != NULL &&
-	    strchr(p+1, '/') == NULL) {
-
-		strcpy(resolved_path, "/dev/mapper/");
-		dst = strchr(resolved_path, 0);
-		for (p = canon+5; *p; ++p) {
-			if (dst - resolved_path >= PATH_MAX - 2)
-				goto fallback;
-			switch (*p) {
-			case '/':
-				*dst = '-';
-				break;
-			case '-':
-				*dst++ = '-';
-				/* fall through */
-			default:
-				*dst = *p;
+	if (strncmp(canon, dev_path, dev_len) == 0 && (p = strchr(canon + dev_len, '/')) != NULL) {
+		if (strchr(p+1, '/') == NULL) {
+			strcpy(resolved_path, dev_mapper_path);
+			dst = strchr(resolved_path, 0);
+			for (p = canon + dev_len; *p; ++p) {
+				if (dst - resolved_path >= PATH_MAX - 2)
+					goto fallback;
+				switch (*p) {
+				case '/':
+					*dst = '-';
+					break;
+				case '-':
+					*dst++ = '-';
+					/* fall through */
+				default:
+					*dst = *p;
+				}
+				++dst;
 			}
-			++dst;
-		}
-		*dst = 0;
+			*dst = 0;
+		} else if (strncmp(canon + dev_len, dev_drbd_res_path + dev_len, dev_drbd_res_len - dev_len) == 0) {
+			/* If the path is a real DRBD path, it's a symlink that points to /dev/drbdXXXX,
+			 * where XXXX are digits. */
+			if (!realpath(canon, resolved_path)) {
+				free(canon);
+				return NULL;
+			}
+
+			/* Try to match /dev/drbd. */
+			if (strncmp(resolved_path, dev_drbd_prefix, dev_drbd_prefix_len) != 0)
+				goto end;
+
+			/* Check the digits. */
+			errno = 0;
+			strtol(resolved_path + dev_drbd_prefix_len, &p, 10);
+			if (p == resolved_path + dev_drbd_prefix_len || errno == ERANGE || *p != '\0')
+				goto end; /* Cannot parse correctly pattern. */
+
+			strcpy(resolved_path, canon);
+		} else
+			goto fallback;
 		if (access(resolved_path, F_OK) == 0)
-			return resolved_path;
+			goto end;
 	}
 
 fallback:
+	free(canon);
 	return realpath(path, resolved_path);
+
+end:
+	free(canon);
+	return resolved_path;
 }
 


### PR DESCRIPTION
Preserve symlinks when "/dev/drbd/by-res/<RES_NAME>/<VOLUME>" paths are used.
It's interesting when a parent is set to a VHD file to avoid usage of
"/dev/drbdXXXX" paths where XXXX is the device minor number.

We can have:
>\> vhd-util query -n /dev/drbd/by-res/volume-d803817e-6113-4b89-abdf-d4ab39d63e8c/0 -p
/dev/drbd/by-res/volume-d5f5a079-0529-4b97-95be-9a859056d523/0

instead of:
>\> vhd-util query -n /dev/drbd/by-res/volume-d803817e-6113-4b89-abdf-d4ab39d63e8c/0 -p
/dev/drbd/./drbd1004

If a DRBD resource exists on many hosts with a resource name equal to an UUID, it can be used
independently of the DRBD device minor number on each host.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>