### PR TITLE
CA-342553: Fix vhd-snapshot with raw parent

### DIFF
--- a/mockatests/vhd/test-vhd-util-snapshot.c
+++ b/mockatests/vhd/test-vhd-util-snapshot.c
@@ -38,9 +38,9 @@
 #include "libvhd.h"
 #include "vhd-wrappers.h"
 
-#define ARGS_SIZE 9
+#define RAW_PRT_ARGS_SIZE 9
 
-char* args[ARGS_SIZE] = {
+char* raw_prt_args[RAW_PRT_ARGS_SIZE] = {
 		"--debug",
 		"-n",
 		"test1.vhdcache",
@@ -51,6 +51,18 @@ char* args[ARGS_SIZE] = {
 		"-e",
 		"-m"};
 
+#define ARGS_SIZE 8
+
+char* args[ARGS_SIZE] = {
+		"--debug",
+		"-n",
+		"test1.vhdcache",
+		"-p",
+		"test2.vhdcache",
+		"-S",
+		"71680",
+		"-e"};
+
 /*
  * Tests to ensure errors are propagated by vhd-util-snapshot.
  */
@@ -59,7 +71,7 @@ void test_vhd_util_snapshot_enospc_from_vhd_snapshot(void **state)
 	will_return(__wrap_canonpath, "testing");
 	will_return(__wrap_vhd_snapshot, ENOSPC);
 	expect_any(__wrap_free, in);
-	int res = vhd_util_snapshot(ARGS_SIZE, args);
+	int res = vhd_util_snapshot(RAW_PRT_ARGS_SIZE, raw_prt_args);
 	assert_int_equal(get_close_count(), 0);
 	assert_int_equal(res, ENOSPC);
 }

--- a/vhd/lib/vhd-util-snapshot.c
+++ b/vhd/lib/vhd-util-snapshot.c
@@ -150,6 +150,7 @@ vhd_util_snapshot(int argc, char **argv)
 			break;
 		case 'S':
 			msize = strtoull(optarg, NULL, 10);
+			break;
 		case 'l':
 			limit = strtol(optarg, NULL, 10);
 			break;

--- a/vhd/lib/vhd-util-snapshot.c
+++ b/vhd/lib/vhd-util-snapshot.c
@@ -226,21 +226,23 @@ vhd_util_snapshot(int argc, char **argv)
 	if(err)
 		goto out;
 
-	/* Set keyhash if it exists in parent */
-	struct vhd_keyhash vhdhash;
-	err = vhd_open(&vhd, backing, VHD_OPEN_RDONLY);
-	if(err)
-		goto out;
-	err = vhd_get_keyhash(&vhd, &vhdhash);
-	vhd_close(&vhd);
-	if(err)
-		goto out;
-	if (vhdhash.cookie == 1){
-		err = vhd_open(&vhd, name, VHD_OPEN_RDWR);
+	if (!vhd_flag_test(flags, VHD_FLAG_CREAT_PARENT_RAW)) {
+		/* Set keyhash if it exists in parent */
+		struct vhd_keyhash vhdhash;
+		err = vhd_open(&vhd, backing, VHD_OPEN_RDONLY);
 		if(err)
 			goto out;
-		err = vhd_set_keyhash(&vhd, &vhdhash);
+		err = vhd_get_keyhash(&vhd, &vhdhash);
 		vhd_close(&vhd);
+		if(err)
+			goto out;
+		if (vhdhash.cookie == 1){
+			err = vhd_open(&vhd, name, VHD_OPEN_RDWR);
+			if(err)
+				goto out;
+			err = vhd_set_keyhash(&vhd, &vhdhash);
+			vhd_close(&vhd);
+		}
 	}
 
 out:


### PR DESCRIPTION
Also address 

* CA-342578: switch case fall through in vhd-util snapshot (identified by Coverity and tripped in the unit tests)