### PR TITLE
Revert "CP-34908: Remove dead write_block function"

### DIFF
--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -360,6 +360,7 @@ int vhd_write_header_at(vhd_context_t *, vhd_header_t *, off64_t);
 int vhd_write_bat(vhd_context_t *, vhd_bat_t *);
 int vhd_write_batmap(vhd_context_t *, vhd_batmap_t *);
 int vhd_write_bitmap(vhd_context_t *, uint32_t block, char *bitmap);
+int vhd_write_block(vhd_context_t *, uint32_t block, char *data);
 
 int vhd_io_read(vhd_context_t *, char *, uint64_t, uint32_t);
 int vhd_io_write(vhd_context_t *, char *, uint64_t, uint32_t);


### PR DESCRIPTION
The function whilst unused in blktap is used in third-party library
consumers.

This reverts commit 62158e24fa12f4f840b118d5c523a78cdd3189be.