### PR TITLE
CA-344424: ensure we don't get division by 0

### DIFF
--- a/cpumond/Makefile.am
+++ b/cpumond/Makefile.am
@@ -3,6 +3,9 @@ AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
 AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/cpumond -fprofile-arcs -ftest-coverage)
 
+AM_CPPFLAGS  = -D_GNU_SOURCE
+AM_CPPFLAGS += -I$(top_srcdir)/include
+
 bin_PROGRAMS = cpumond
 
 cpumond_SOURCES  = cpumond.c

--- a/cpumond/cpumond.c
+++ b/cpumond/cpumond.c
@@ -38,6 +38,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include "compiler.h"
 #include "cpumond.h"
 
 #ifndef DEBUG
@@ -169,6 +170,11 @@ int cpumond_loop(cpumond_entry_t *cpumond_entry){
     while(run){
         if (statread(statfd, &total2, &idle2) != 0)
             goto out;
+
+	if (unlikely(total2 == total1)) {
+		sleep(1);
+		continue;
+	}
 
         cpumond_entry->mm->curr = 100.0 *
             ((total2-total1)-(idle2-idle1))/(total2-total1);


### PR DESCRIPTION
Another coverity find.

Signed-off-by: Mark Syms <mark.syms@citrix.com>