### PR TITLE
Add a unit test for canonpath that exercises the code affected by CA-345193

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Makefile.in
 /mockatests/cbt/test-cbt-util
 /mockatests/control/test-control
 /mockatests/drivers/test-drivers
+/mockatests/vhd/test-vhd-util
 /vhd/vhd-index
 /vhd/vhd-update
 /vhd/vhd-util

--- a/collect-test-results.sh
+++ b/collect-test-results.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 OUTPUT_DIR=$(realpath $1)
 
 if [ -z $OUTPUT_DIR ]; then
@@ -9,7 +11,7 @@ fi
 
 mkdir -p $OUTPUT_DIR
 
-find . -name \*.gcda -exec rm {}\;
+find . -name \*.gcda -exec rm {} \;
 
 lcov --capture --initial --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage_base.info
 
@@ -20,3 +22,5 @@ lcov --rc lcov_branch_coverage=1 --add-tracefile $OUTPUT_DIR/coverage_base.info 
 genhtml $OUTPUT_DIR/coverage.info  --rc lcov_branch_coverage=1 --output-directory $OUTPUT_DIR/coverage-html
 tar cf $OUTPUT_DIR/test-results.tar `find mockatests -name \*.log`
 tar cf $OUTPUT_DIR/gcov-files.tar `find . -name \*.gcda -or -name \*.gcno`
+
+lcov -l $OUTPUT_DIR/coverage.info

--- a/mockatests/vhd/Makefile.am
+++ b/mockatests/vhd/Makefile.am
@@ -9,10 +9,10 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/cbt -I../include
 check_PROGRAMS = test-vhd-util
 TESTS = test-vhd-util
 
-test_vhd_util_SOURCES = test-vhd-util.c test-vhd-util-snapshot.c vhd-wrappers.c
+test_vhd_util_SOURCES = test-vhd-util.c test-vhd-util-snapshot.c test-canonpath.c vhd-wrappers.c
 test_vhd_util_LDFLAGS = $(top_srcdir)/vhd/lib/libvhd.la -lcmocka -luuid
 test_vhd_util_LDFLAGS += -static-libtool-libs
-test_vhd_util_LDFLAGS += -Wl,--wrap=free
+test_vhd_util_LDFLAGS += -Wl,--wrap=free,--wrap=malloc,--wrap=realloc
 test_vhd_util_LDFLAGS += -Wl,--wrap=canonpath
 test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_flag_test
 test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_snapshot
@@ -20,3 +20,4 @@ test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_open
 test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_get_keyhash
 test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_set_keyhash
 test_vhd_util_LDFLAGS += -Wl,--wrap=vhd_close
+test_vhd_util_LDFLAGS += -Wl,--wrap=get_current_dir_name,--wrap=realpath

--- a/mockatests/vhd/test-canonpath.c
+++ b/mockatests/vhd/test-canonpath.c
@@ -5,14 +5,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  1. Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *  2. Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the names of its 
- *     contributors may be used to endorse or promote products derived from 
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
  *     this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -27,32 +27,44 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <stddef.h>
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
-
+#include <errno.h>
 #include <wrappers.h>
+#include <limits.h>
+
 #include "test-suites.h"
+#include "libvhd.h"
+#include "vhd-wrappers.h"
 
-static int setupRealAllocator(void **state)
+char *
+__real_canonpath(const char *path, char *resolved_path);
+
+void test_vhd_util_canon_path_relative_success(void **state)
 {
-	set_use_real_allocator(true);
-	return 0;
-}
+	char *ppath, __ppath[PATH_MAX];
+	char *pname = "6f95a71c-4961-4af0-aec4-58bc3bbef254.vhd";
+	char *test_dir = "/run/sr-mount/test";
+	char *test_path = "/run/sr-mount/test/6f95a71c-4961-4af0-aec4-58bc3bbef254.vhd";
 
-static int teardownRealAllocator(void **state)
-{
-	set_use_real_allocator(false);
-	return 0;
-}
+	char *dir_name_return = test_malloc(strlen(test_dir) + 1);
+	strncpy(dir_name_return, test_dir, strlen(test_dir) + 1);
 
-int main(void)
-{
-	int result =
-		cmocka_run_group_tests_name("Snapshot tests", vhd_snapshot_tests, setupRealAllocator, teardownRealAllocator) +
-		cmocka_run_group_tests_name("Canonpath tests", canonpath_tests, NULL, NULL);
+	char *realpath_return = test_malloc(strlen(test_path) + 1);
+	strncpy(realpath_return, test_path, strlen(test_path) + 1);
 
-	return result;
+	will_return(__wrap_get_current_dir_name, dir_name_return);
+	will_return(__wrap_realpath, realpath_return);
+
+	/* Have to call __real_canonpath here to bypass the wrapping
+	   done for testing the snapshot commands.
+	 */
+	ppath = __real_canonpath(pname, __ppath);
+
+	fprintf(stderr, "ppath %s\n", ppath);
+
+	assert_non_null(ppath);
+	test_free(ppath);
 }

--- a/mockatests/vhd/test-suites.h
+++ b/mockatests/vhd/test-suites.h
@@ -61,4 +61,11 @@ static const struct CMUnitTest vhd_snapshot_tests[] = {
 	cmocka_unit_test_setup(test_vhd_util_snapshot_einval_from_vhd_set_keyhash, setup)
 };
 
+/* 'canonpath' tests */
+void test_vhd_util_canon_path_relative_success(void **state);
+
+static const struct CMUnitTest canonpath_tests[] = {
+	cmocka_unit_test(test_vhd_util_canon_path_relative_success)
+};
+
 #endif /* __TEST_SUITES_H__ */

--- a/mockatests/vhd/test-vhd-util-snapshot.c
+++ b/mockatests/vhd/test-vhd-util-snapshot.c
@@ -70,7 +70,7 @@ void test_vhd_util_snapshot_enospc_from_vhd_snapshot(void **state)
 {
 	will_return(__wrap_canonpath, "testing");
 	will_return(__wrap_vhd_snapshot, ENOSPC);
-	expect_any(__wrap_free, in);
+	expect_any(__wrap_free, ptr);
 	int res = vhd_util_snapshot(RAW_PRT_ARGS_SIZE, raw_prt_args);
 	assert_int_equal(get_close_count(), 0);
 	assert_int_equal(res, ENOSPC);
@@ -81,7 +81,7 @@ void test_vhd_util_snapshot_einval_from_vhd_open(void **state)
 	will_return(__wrap_canonpath, "testing");
 	will_return(__wrap_vhd_snapshot, 0);
 	will_return(__wrap_vhd_open, EINVAL);
-	expect_any(__wrap_free, in);
+	expect_any(__wrap_free, ptr);
 	int res = vhd_util_snapshot(ARGS_SIZE, args);
 	assert_int_equal(get_close_count(), 0);
 	assert_int_equal(res, EINVAL);
@@ -95,7 +95,7 @@ void test_vhd_util_snapshot_einval_from_vhd_get_keyhash(void **state)
 	will_return(__wrap_vhd_get_keyhash, EINVAL);
 	will_return(__wrap_vhd_close, 0);
 	expect_any(__wrap_vhd_close, ctx);
-	expect_any(__wrap_free, in);
+	expect_any(__wrap_free, ptr);
 	int res = vhd_util_snapshot(ARGS_SIZE, args);
 	assert_int_equal(get_close_count(), 1);
 	assert_int_equal(res, EINVAL);
@@ -111,7 +111,7 @@ void test_vhd_util_snapshot_einval_from_vhd_open_cookie(void **state)
 	expect_any(__wrap_vhd_close, ctx);
 	int err[] = {0, EINVAL};
 	set_open_errors(2, err);
-	expect_any(__wrap_free, in);
+	expect_any(__wrap_free, ptr);
 	int res = vhd_util_snapshot(ARGS_SIZE, args);
 	assert_int_equal(get_close_count(), 1);
 	assert_int_equal(res, EINVAL);
@@ -127,7 +127,7 @@ void test_vhd_util_snapshot_einval_from_vhd_set_keyhash(void **state)
 	will_return_always(__wrap_vhd_close, 0);
 	will_return(__wrap_vhd_set_keyhash, EINVAL);
 	expect_any_count(__wrap_vhd_close, ctx, 2);
-	expect_any(__wrap_free, in);
+	expect_any(__wrap_free, ptr);
 	int res = vhd_util_snapshot(ARGS_SIZE, args);
 	assert_int_equal(get_close_count(), 2);
 	assert_int_equal(res, EINVAL);

--- a/mockatests/vhd/vhd-wrappers.h
+++ b/mockatests/vhd/vhd-wrappers.h
@@ -37,5 +37,6 @@ void set_cookie();
 void set_open_errors(int, int*);
 void enable_control_mocks();
 void disable_control_mocks();
+void set_use_real_allocator(bool val);
 
 #endif /* __VHD_WRAPPERS_H__ */


### PR DESCRIPTION
If the fix in https://github.com/xapi-project/blktap/pull/335 is reverted in the presence of this unit test it will correctly fail with a buffer overrun error.