### PR TITLE
CP-35115 - New fixed style nbd option negotiation.

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -36,6 +36,7 @@ libtapdisk_la_SOURCES += tapdisk-vbd.h
 libtapdisk_la_SOURCES += linux-blktap.h
 libtapdisk_la_SOURCES += tapdisk-blktap.c
 libtapdisk_la_SOURCES += tapdisk-blktap.h
+libtapdisk_la_SOURCES += tapdisk-protocol-new.h
 libtapdisk_la_SOURCES += tapdisk-nbdserver.c
 libtapdisk_la_SOURCES += tapdisk-nbdserver.h
 libtapdisk_la_SOURCES += tapdisk-image.c

--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -107,7 +107,7 @@ tapdisk_image_check_td_request(td_image_t *image, td_request_t treq)
 	info   = &image->info;
 	rdonly = td_flag_test(image->flags, TD_OPEN_RDONLY);
 
-	if (treq.op != TD_OP_READ && treq.op != TD_OP_WRITE)
+	if (treq.op != TD_OP_READ && treq.op != TD_OP_WRITE && treq.op != TD_OP_BLOCK_STATUS)
 		goto fail;
 
 	if (treq.op == TD_OP_WRITE && rdonly) {
@@ -159,7 +159,8 @@ tapdisk_image_check_request(td_image_t *image, td_vbd_request_t *vreq)
 			goto fail;
 		}
 		/* continue */
-	case TD_OP_READ:
+	case TD_OP_READ: /* fall through */
+	case TD_OP_BLOCK_STATUS:
 		if (vreq->sec + secs > info->size) {
 			err = -EINVAL;
 			goto fail;

--- a/drivers/tapdisk-interface.c
+++ b/drivers/tapdisk-interface.c
@@ -234,6 +234,40 @@ fail:
 }
 
 void
+td_queue_block_status(td_image_t *image, td_request_t *treq)
+{
+	int err;
+	td_driver_t *driver;
+
+	driver = image->driver;
+	if (!driver) {
+		err = -ENODEV;
+		goto fail;
+	}
+
+	if (!td_flag_test(driver->state, TD_DRIVER_OPEN)) {
+		err = -EBADF;
+		goto fail;
+	}
+
+	if (!driver->ops->td_queue_block_status) {
+		err = -EOPNOTSUPP;
+		goto fail;
+	}
+
+	err = tapdisk_image_check_td_request(image, *treq);
+	if (err)
+		goto fail;
+
+	driver->ops->td_queue_block_status(driver, *treq);
+
+	return;
+
+fail:
+	td_complete_request(*treq, err);
+}
+
+void
 td_forward_request(td_request_t treq)
 {
 	tapdisk_vbd_forward_request(treq);

--- a/drivers/tapdisk-interface.h
+++ b/drivers/tapdisk-interface.h
@@ -45,6 +45,7 @@ int td_validate_parent(td_image_t *, td_image_t *);
 
 void td_queue_write(td_image_t *, td_request_t);
 void td_queue_read(td_image_t *, td_request_t);
+void td_queue_block_status(td_image_t*, td_request_t*);
 void td_forward_request(td_request_t);
 void td_complete_request(td_request_t, int);
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -1435,7 +1435,10 @@ tapdisk_nbdserver_unpause(td_nbdserver_t *server)
 
 	list_for_each_entry_safe(pos, q, &server->clients, clientlist){
 		if (pos->paused == 1) {
-			tapdisk_nbdserver_enable_client(pos);
+			if((err = tapdisk_nbdserver_enable_client(pos)) < 0) {
+				ERR("Failed to enable nbd client after pause");
+				return err;
+			}
 			pos->paused = 0;
 		}
 	}

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -40,6 +40,8 @@
 #include <arpa/inet.h>
 #include <sys/wait.h>
 #include <sys/un.h>
+#include "tapdisk-protocol-new.h"
+#include <byteswap.h>
 
 #include "debug.h"
 #include "tapdisk.h"
@@ -57,7 +59,13 @@
 #include "config.h"
 #endif
 
+#define MAX_OPTIONS 32
+
 #define NBD_SERVER_NUM_REQS TAPDISK_DATA_REQUESTS
+#define MAX_REQUEST_SIZE (64 * 1024 * 1024)
+
+uint16_t gflags = (NBD_FLAG_FIXED_NEWSTYLE | NBD_FLAG_NO_ZEROES);
+static const int SERVER_USE_OLD_PROTOCOL = 1;
 
 /*
  * Server
@@ -81,6 +89,90 @@ struct td_nbdserver_req {
 	struct td_iovec         iov;
 };
 
+void
+free_extents(struct tapdisk_extents *extents)
+{
+	tapdisk_extent_t *next, *curr_extent = extents->head;
+	while (curr_extent) {
+		next = curr_extent->next;
+		free(curr_extent);
+		curr_extent = next;
+	}
+
+	free(extents);
+}
+
+struct nbd_block_descriptor *
+convert_extents_to_block_descriptors (struct tapdisk_extents *extents)
+{
+    size_t i, nr_extents = extents->count;
+    struct nbd_block_descriptor *blocks;
+    tapdisk_extent_t *curr_extent = extents->head;
+    
+    blocks = calloc (nr_extents, sizeof (struct nbd_block_descriptor));
+    if(blocks == NULL) {
+	    return NULL;
+    }
+
+    for (i = 0; i < nr_extents; ++i) {
+      blocks[i].length = htobe32 ((curr_extent->length << SECTOR_SHIFT));
+      blocks[i].status_flags = htobe32(curr_extent->flag);
+      curr_extent = curr_extent->next;
+    }
+    return blocks;
+}
+
+static int
+send_structured_reply_block_status (int fd, char* id, struct tapdisk_extents *extents)
+{
+	struct nbd_structured_reply reply;
+	struct nbd_block_descriptor *blocks;
+	size_t i, nr_blocks = extents->count;
+	uint32_t context_id;
+	int ret = 0;
+
+	blocks = convert_extents_to_block_descriptors (extents);
+	if(blocks == NULL) {
+		ERR("Could not allocate blocks for extents");
+		ret = -1;
+		goto done;
+	}	
+
+	reply.magic = htobe32 (NBD_STRUCTURED_REPLY_MAGIC);
+	memcpy(&reply.handle, id, sizeof(reply.handle));
+	reply.flags = htobe16 (NBD_REPLY_FLAG_DONE);
+	reply.type = htobe16 (NBD_REPLY_TYPE_BLOCK_STATUS);
+	reply.length = htobe32 (sizeof context_id +
+				nr_blocks * sizeof (struct nbd_block_descriptor));
+
+	int rc = send (fd, &reply, sizeof(reply), 0);
+	if(rc != sizeof(reply)) {
+		ERR("Could  not send stuctured reply struct");
+		ret = -errno;
+		goto done;
+	}	
+
+	context_id = htobe32 (base_allocation_id);
+	rc = send (fd, &context_id, sizeof(context_id), 0);
+	if(rc != sizeof(context_id)) {
+		ERR("Could  not send contect_id");
+		ret = -errno;
+		goto done;
+	}	
+
+	for (i = 0; i < nr_blocks; ++i) {
+		rc = send (fd, &blocks[i], sizeof blocks[i], 0);
+		if(rc != sizeof(blocks[i])) {
+			ERR("Could not send extent block");
+			ret = -errno;
+			goto done;
+		}	
+	}
+done:
+	free(blocks);
+	return ret;   
+}
+
 td_nbdserver_req_t *
 tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 {
@@ -92,6 +184,24 @@ tapdisk_nbdserver_alloc_request(td_nbdserver_client_t *client)
 		req = client->reqs_free[--client->n_reqs_free];
 
 	return req;
+}
+
+static int
+send_option_reply (int new_fd, uint32_t option, uint32_t reply)
+{
+	struct nbd_fixed_new_option_reply fixed_new_option_reply;
+
+	fixed_new_option_reply.magic = htobe64 (NBD_REP_MAGIC);
+	fixed_new_option_reply.option = htobe32 (option);
+	fixed_new_option_reply.reply = htobe32 (reply);
+	fixed_new_option_reply.replylen = htobe32 (0);
+
+	int rc = send(new_fd, &fixed_new_option_reply, sizeof(fixed_new_option_reply), 0);
+	if(rc != sizeof(fixed_new_option_reply)) {
+		ERR("Failed to send new_option_reply");
+		return -1; 
+	}
+	return 0;
 }
 
 static void
@@ -131,6 +241,300 @@ tapdisk_nbdserver_reqs_free(td_nbdserver_client_t *client)
 		free(client->reqs_free);
 		client->reqs_free = NULL;
 	}
+}
+
+void
+provide_server_info (td_nbdserver_t *server, uint64_t *exportsize, uint16_t *flags)
+{
+	int64_t size;
+	uint16_t eflags = NBD_FLAG_HAS_FLAGS;
+
+	size = server->info.size * server->info.sector_size;
+
+	*exportsize = size;
+	*flags = eflags;
+}
+
+static int 
+send_info_export (int new_fd, uint32_t option, uint32_t reply, uint16_t info, uint64_t exportsize,
+		  uint16_t flags)
+{
+	struct nbd_fixed_new_option_reply fixed_new_option_reply;
+	struct nbd_fixed_new_option_reply_info_export export;
+
+	fixed_new_option_reply.magic = htobe64 (NBD_REP_MAGIC);
+	fixed_new_option_reply.option = htobe32 (option);
+	fixed_new_option_reply.reply = htobe32 (reply);
+	fixed_new_option_reply.replylen = htobe32 (sizeof export);
+
+	export.info = htobe16 (info);
+	export.exportsize = htobe64 (exportsize);
+	export.eflags = htobe16 (flags);
+
+	int rc = send(new_fd, &fixed_new_option_reply, sizeof(fixed_new_option_reply), 0);
+	if(rc != sizeof(fixed_new_option_reply)) {
+		ERR("Failed to send new_option_reply");
+		return -1; 
+	}
+
+	rc = send(new_fd, &export, sizeof(export), 0);
+	if(rc != sizeof(export)) {
+		ERR("Failed to send info export");
+		return -1; 
+	}
+
+	return 0;
+}
+
+int
+send_meta_context (int new_fd, uint32_t reply, uint32_t context_id, const char *name)
+{
+	struct nbd_fixed_new_option_reply fixed_new_option_reply;
+	struct nbd_fixed_new_option_reply_meta_context context;
+	const size_t namelen = strlen (name);
+
+	fixed_new_option_reply.magic = htobe64 (NBD_REP_MAGIC);
+	fixed_new_option_reply.option = htobe32 (NBD_OPT_SET_META_CONTEXT);
+	fixed_new_option_reply.reply = htobe32 (reply);
+	fixed_new_option_reply.replylen = htobe32 (sizeof context + namelen);
+	context.context_id = htobe32 (context_id);
+
+	int rc = send (new_fd, &fixed_new_option_reply, sizeof(fixed_new_option_reply), 0);
+	if(rc != sizeof(fixed_new_option_reply)) {
+		ERR("Failed to send new_option_reply");
+		return -1; 
+	}
+	rc = send (new_fd, &context, sizeof(context), 0);
+	if(rc != sizeof(fixed_new_option_reply)) {
+		ERR("Failed to send context");
+		return -1; 
+	}
+	rc = send (new_fd, name, namelen, 0);
+	if(rc != sizeof(fixed_new_option_reply)) {
+		ERR("Failed to send name");
+		return -1; 
+	}
+
+	return 0;
+}
+
+int
+receive_info(int fd, char* buf, int size)
+{
+	int n = 0;
+	int hdrlen = size;
+
+	while (n < size) {
+		int rc = recv(fd, buf + n, hdrlen - n, 0);
+		if (rc == 0) {
+			ERR("Connection was closed by client");
+			return -1;
+		}
+		if (rc < 0) {
+			rc = errno;
+			ERR("Client caused following error %s", strerror(rc));
+			return -rc;
+		}
+		n += rc;
+	}
+
+	return 0;
+}
+
+static int
+receive_newstyle_options(td_nbdserver_t *server, int new_fd, bool no_zeroes)
+{
+	struct nbd_new_option n_option;
+	size_t n_options;
+	uint32_t opt_code;
+	uint32_t opt_len;
+	uint64_t opt_version;
+	uint64_t exportsize;
+	struct nbd_export_name_option_reply handshake_finish;
+	char *buf = NULL;
+	int ret = 0;
+
+	for (n_options = 0; n_options < MAX_OPTIONS; n_options++) {
+
+		if(receive_info(new_fd, (char *)&n_option, sizeof(n_option)) == -1){
+			return -1;	
+		}
+
+		opt_version = be64toh(n_option.version);
+		if (NBD_OPT_MAGIC != opt_version){
+			ERR("Bad NBD option version %" PRIx64
+			    ", expected %" PRIx64,
+                            opt_version, NBD_OPT_MAGIC);
+			ret = -1;	
+			goto done;
+		}
+
+		opt_len = be32toh (n_option.optlen);
+		if (opt_len > MAX_REQUEST_SIZE) {
+			ERR ("NBD optlen to big (%" PRIu32 ")", opt_len);
+			ret = -1;	
+			goto done;
+		}
+
+		buf = malloc (opt_len + 1); 
+		if (buf == NULL) {
+			ERR("Could not malloc option data buff");
+			ret = -1;	
+			goto done;
+		}
+
+		opt_code = be32toh (n_option.option);
+
+		switch (opt_code) {
+		case NBD_OPT_EXPORT_NAME:
+		{
+			INFO("Processing NBD_OPT_EXORT_NAME");
+			uint16_t flags = 0;
+			if(receive_info(new_fd, (char *)buf, opt_len) == -1){
+				ERR ("Failed to received data for NBD_OPT_EXPORT_NAME");
+				ret = -1;	
+				goto done;
+			}
+			buf[opt_len] = '\0';
+			INFO("Exportname %s", buf);
+
+			provide_server_info(server, &exportsize, &flags);
+
+			bzero(&handshake_finish, sizeof handshake_finish);
+			handshake_finish.exportsize = htobe64 (exportsize);
+      			handshake_finish.eflags = htobe16 (flags);
+			ssize_t len = no_zeroes ? 10 : sizeof(handshake_finish);
+			ssize_t sent = send (new_fd, &handshake_finish,len, 0);
+			if(sent != len) {
+				ERR ("Failed to send handshake finish");
+				ret = -1;	
+				goto done;
+			}
+		}
+		break;
+		case NBD_OPT_ABORT:
+			ERR("NBD_OPT_ABORT: not implemented");
+			break;
+		case NBD_OPT_LIST:
+			ERR("NBD_OPT_LIST: not implemented");
+			break;
+		case NBD_OPT_STARTTLS:
+			ERR("NBD_OPT_STARTTLS: not implemented");
+			break;
+		case NBD_OPT_INFO:
+			ERR("NBD_OPT_INFO: not implemented");
+			break;
+		case NBD_OPT_GO:
+		{   
+			uint16_t flags;
+			INFO("Processing NBD_OPT_EXORT_NAME");
+
+			provide_server_info(server, &exportsize, &flags);
+	
+			if (send_info_export (new_fd, opt_code,
+                                                    NBD_REP_INFO,
+                                                    NBD_INFO_EXPORT,
+                                                    exportsize, flags) == -1){
+				ERR("Could not send reply info export");
+				ret = -1;	
+				goto done;
+			}
+			
+			/* 
+			 * We could read the option infos here but nothing we
+			 * connect to seems to use them
+			 */
+			if (send_option_reply (new_fd, NBD_OPT_GO, NBD_REP_ACK) == -1){
+				ERR("Could not send new style option reply");
+				ret = -1;	
+				goto done;
+			}
+		}
+			break;
+		case NBD_OPT_STRUCTURED_REPLY:
+			/* 
+			 * We are always going to do structured replies so just acknowledge the
+			 * request
+			 */
+			INFO("Processing NBD_OPT_STRUCTURED_REPLY");
+			if (opt_len != 0) {
+				send_option_reply (new_fd, opt_code, NBD_REP_ERR_INVALID);
+				ret = -1;	
+				goto done;
+			} 
+	  
+			if (send_option_reply (new_fd, opt_code, NBD_REP_ACK) == -1){
+				ret = -1;	
+				goto done;
+			}
+	  
+			break;
+		case NBD_OPT_LIST_META_CONTEXT:
+			ERR("NBD_OPT_LIST_META_CONTEXT: not implemented");
+			break;
+		case NBD_OPT_SET_META_CONTEXT:
+		{
+			INFO("Processing NBD_OPT_SET_META_CONTEXT");
+			uint32_t opt_index;
+			uint32_t exportnamelen;
+			uint32_t nr_queries;
+			uint32_t querylen;
+			if (recv(new_fd, buf, opt_len, 0) == -1){
+				ret = -1;	
+				goto done;
+			}
+        
+			memcpy (&exportnamelen, &buf[0], 4);
+			exportnamelen = be32toh (exportnamelen);
+			opt_index = 4 + exportnamelen;
+	
+			memcpy (&nr_queries, &buf[opt_index], 4);
+			nr_queries = be32toh (nr_queries);
+			opt_index += 4;
+			while (nr_queries > 0) {
+				char temp[16];
+				memcpy (&querylen, &buf[opt_index], 4);
+				querylen = be32toh (querylen);
+				opt_index += 4;
+				memcpy (temp, &buf[opt_index], 15);
+				temp[15]= '\0';
+				INFO("actual string %s\n", temp);
+				if (querylen == 15 && strncmp (&buf[opt_index], "base:allocation", 15) == 0) {
+				    if(send_meta_context (new_fd, NBD_REP_META_CONTEXT, 1, "base:allocation") !=0) {
+					ret = -1;	
+					goto done;
+				    }
+				}
+				nr_queries--;
+			}
+			if (send_option_reply (new_fd, opt_code, NBD_REP_ACK) == -1){
+				ret = -1;	
+				goto done;
+			}
+		}
+			break;
+		default:
+			ret = -1;	
+			goto done;
+		}
+
+		free(buf);
+		buf = NULL;
+
+		/* Loop ends here for these commands */
+		if (opt_code == NBD_OPT_GO || opt_code == NBD_OPT_EXPORT_NAME )
+			break;
+	} 
+
+	if (n_options >= MAX_OPTIONS) {
+		ERR("Max number of nbd options exceeded (%d)", MAX_OPTIONS);
+		ret = -1;	
+		goto done;
+	}
+
+done:
+	free(buf);
+	return ret;
 }
 
 int
@@ -281,6 +685,19 @@ static void
 }
 
 static void
+__tapdisk_nbdserver_block_status_cb(td_vbd_request_t *vreq, int err,
+		void *token, int final)
+{
+	td_nbdserver_client_t *client = token;
+	td_nbdserver_req_t *req = container_of(vreq, td_nbdserver_req_t, vreq);
+	tapdisk_extents_t* extents = (tapdisk_extents_t *)(vreq->data);
+	send_structured_reply_block_status (client->client_fd, req->id, extents);
+	free_extents(extents);
+	free(vreq->iov->base);
+	tapdisk_nbdserver_free_request(client, req);
+}
+
+static void
 __tapdisk_nbdserver_request_cb(td_vbd_request_t *vreq, int error,
 		void *token, int final)
 {
@@ -358,8 +775,58 @@ finish:
 	tapdisk_nbdserver_free_request(client, req);
 }
 
+void
+tapdisk_nbdserver_handshake_cb(event_id_t id, char mode, void *data)
+{
+	uint32_t cflags = 0;
+
+	td_nbdserver_t *server = (td_nbdserver_t* )data;
+
+	int rc = recv(server->handshake_fd, &cflags, sizeof(cflags), 0);
+	if(rc < sizeof(cflags)) {
+		ERR("Could not receive client flags");
+		return;
+	}
+
+	cflags = be32toh (cflags);
+	bool no_zeroes = (NBD_FLAG_NO_ZEROES & cflags) != 0;
+
+        /* Receive newstyle options. */
+        if (receive_newstyle_options (server, server->handshake_fd, no_zeroes) == -1){
+		ERR("Option negotiation messed up");
+	}
+
+	tapdisk_server_unregister_event(id);
+}
+
+int
+tapdisk_nbdserver_new_protocol_handshake(td_nbdserver_t *server, int new_fd)
+{
+	struct nbd_new_handshake handshake;
+
+	handshake.nbdmagic = htobe64 (NBD_MAGIC);
+	handshake.version = htobe64 (NBD_NEW_VERSION);
+	handshake.gflags = htobe16 (gflags);
+
+	int rc = send(new_fd, &handshake, sizeof(handshake), 0);
+	if (rc != sizeof(handshake)) {
+		ERR("Sending newstyle handshake");
+		return -1;
+	}
+	server->handshake_fd = new_fd;
+	/* We may need to wait upto 40 seconds for a reply especially during
+	 * SXM contexts, so setup an event and return so that tapdisk is 
+	 * reponsive during the interim*/
+
+	tapdisk_server_register_event( SCHEDULER_POLL_READ_FD,
+				       new_fd, TV_ZERO,
+				       tapdisk_nbdserver_handshake_cb,
+				       server);
+	return 0;
+}
+
 static void
-tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
+tapdisk_nbdserver_newclient_fd_old(td_nbdserver_t *server, int new_fd)
 {
 	td_nbdserver_client_t *client;
 	char buffer[256];
@@ -416,6 +883,48 @@ tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
 	}
 }
 
+static void
+tapdisk_nbdserver_newclient_fd_new_fixed(td_nbdserver_t *server, int new_fd)
+{
+	td_nbdserver_client_t *client;
+
+	ASSERT(server);
+	ASSERT(new_fd >= 0);
+
+	INFO("Got a new client!");
+
+	if(tapdisk_nbdserver_new_protocol_handshake(server, new_fd) != 0)
+		return;
+
+	INFO("About to alloc client");
+	client = tapdisk_nbdserver_alloc_client(server);
+	if (client == NULL) {
+		ERR("Error allocating client");
+		close(new_fd);
+		return;
+	}
+
+	INFO("Got an allocated client at %p", client);
+	client->client_fd = new_fd;
+
+	INFO("About to enable client on fd %d", client->client_fd);
+	if (tapdisk_nbdserver_enable_client(client) < 0) {
+		ERR("Error enabling client");
+		tapdisk_nbdserver_free_client(client);
+		close(new_fd);
+	}
+}
+
+static void
+tapdisk_nbdserver_newclient_fd(td_nbdserver_t *server, int new_fd)
+{
+	if(SERVER_USE_OLD_PROTOCOL){
+		tapdisk_nbdserver_newclient_fd_old(server, new_fd);
+	} else {
+		tapdisk_nbdserver_newclient_fd_new_fixed(server, new_fd);
+	}
+}	
+
 void
 tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 {
@@ -448,16 +957,17 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	n = 0;
 	ptr = (char *) &request;
 	while (n < hdrlen) {
-		// FIXME: need to select() on fd with a sensible timeout
 		rc = recv(fd, ptr + n, hdrlen - n, 0);
 		if (rc == 0) {
-			INFO("Client closed connection");
+			rc = errno;
+			if (rc == EAGAIN)
+				return;
 			goto fail;
 		}
 		if (rc < 0) {
 			rc = errno;
-			ERR("failed to receive from client: %s. Closing connection",
-					strerror(rc));
+			ERR("failed to receive from client errno: %s. Closing connection",
+			    strerror(rc));
 			goto fail;
 		}
 		n += rc;
@@ -523,7 +1033,19 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 		tapdisk_nbdserver_newclient_fd(server, fd);
 		INFO("Sent initial connection message");
 		return;
-
+	case TAPDISK_NBD_CMD_BLOCK_STATUS:
+	{
+		tapdisk_extents_t *extents = (tapdisk_extents_t*)malloc(sizeof(tapdisk_extents_t));
+		if(extents == NULL) {
+			ERR("Could not allocate memory for tapdisk_extents_t");
+			goto fail;
+		}	
+		bzero(extents, sizeof(tapdisk_extents_t));
+		vreq->data = extents;
+		vreq->cb = __tapdisk_nbdserver_block_status_cb;
+		vreq->op = TD_OP_BLOCK_STATUS;
+	}
+		break;
 	default:
 		ERR("Unsupported operation: 0x%x", request.type);
 		goto fail;
@@ -775,7 +1297,7 @@ tapdisk_nbdserver_listen_inet(td_nbdserver_t *server, const int port)
 	}
 
 	for (p = servinfo; p != NULL; p = p->ai_next) {
-		if ((server->fdrecv_listening_fd = socket(AF_INET, SOCK_STREAM, 0)) ==
+		if ((server->fdrecv_listening_fd = socket(AF_INET, SOCK_STREAM|SOCK_NONBLOCK, 0)) ==
 				-1) {
 			ERR("Failed to create socket");
 			continue;

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -47,8 +47,13 @@ typedef struct td_nbdserver_client td_nbdserver_client_t;
 
 enum {
 	TAPDISK_NBD_CMD_READ = 0,
-	TAPDISK_NBD_CMD_WRITE = 1,
-	TAPDISK_NBD_CMD_DISC = 2
+	TAPDISK_NBD_CMD_WRITE,
+	TAPDISK_NBD_CMD_DISC,
+	TAPDISK_NBD_CMD_FLUSH,
+	TAPDISK_NBD_CMD_TRIM,
+	TAPDISK_NBD_CMD_CACHE,
+	TAPDISK_NBD_CMD_WRITE_ZEROES,
+	TAPDISK_NBD_CMD_BLOCK_STATUS
 };
 
 struct nbd_request {
@@ -91,6 +96,11 @@ struct td_nbdserver {
 	 * Listening file descriptor for the NBD server on the UNIX domain socket.
 	 */
 	int                     unix_listening_fd;
+
+	/**
+	 * Socket opened during handshake negotiation.
+	 */
+	int                     handshake_fd;
 
 	/**
 	 * Event ID for the file descriptor receiver.
@@ -176,5 +186,8 @@ void tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
  * Tells how many requests are pending.
  */
 int tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client);
+
+int tapdisk_nbdserver_new_protocol_handshake(td_nbdserver_t*, int);
+void tapdisk_nbdserver_handshake_cb(event_id_t, char, void*);
 
 #endif /* _TAPDISK_NBDSERVER_H_ */

--- a/drivers/tapdisk-protocol-new.h
+++ b/drivers/tapdisk-protocol-new.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _TAPDISK_PROTOCOL_NEW_H_
+#define _TAPDISK_PROTOCOL_NEW_H_
+
+#define NBD_REP_ERR(val) (0x80000000 | (val))
+#define NBD_MAGIC       UINT64_C(0x4e42444d41474943) /* ASCII "NBDMAGIC" */
+#define NBD_OLD_VERSION UINT64_C(0x0000420281861253)
+#define NBD_OPT_MAGIC UINT64_C(0x49484156454F5054) /* ASCII "IHAVEOPT" */
+
+#define NBD_NEW_VERSION UINT64_C(0x49484156454F5054) /* ASCII "IHAVEOPT" */
+
+#define NBD_INFO_EXPORT      0
+#define NBD_INFO_NAME        1
+#define NBD_INFO_DESCRIPTION 2
+#define NBD_INFO_BLOCK_SIZE  3
+
+#define NBD_REP_MAGIC UINT64_C(0x3e889045565a9)
+
+#define NBD_FLAG_FIXED_NEWSTYLE    (1 << 0)
+#define NBD_FLAG_NO_ZEROES         (1 << 1)
+
+#define NBD_FLAG_HAS_FLAGS         (1 << 0)
+#define NBD_FLAG_READ_ONLY         (1 << 1)
+#define NBD_FLAG_SEND_FLUSH        (1 << 2)
+#define NBD_FLAG_SEND_FUA          (1 << 3)
+#define NBD_FLAG_ROTATIONAL        (1 << 4)
+#define NBD_FLAG_SEND_TRIM         (1 << 5)
+#define NBD_FLAG_SEND_WRITE_ZEROES (1 << 6)
+#define NBD_FLAG_SEND_DF           (1 << 7)
+#define NBD_FLAG_CAN_MULTI_CONN    (1 << 8)
+#define NBD_FLAG_SEND_CACHE        (1 << 10)
+#define NBD_FLAG_SEND_FAST_ZERO    (1 << 11)
+
+#define NBD_OPT_EXPORT_NAME        1
+#define NBD_OPT_ABORT              2
+#define NBD_OPT_LIST               3
+#define NBD_OPT_STARTTLS           5
+#define NBD_OPT_INFO               6
+#define NBD_OPT_GO                 7
+#define NBD_OPT_STRUCTURED_REPLY   8
+#define NBD_OPT_LIST_META_CONTEXT  9
+#define NBD_OPT_SET_META_CONTEXT   10
+
+#define NBD_STRUCTURED_REPLY_MAGIC  0x668e33ef
+
+#define NBD_REPLY_FLAG_DONE         (1<<0)
+
+#define NBD_REPLY_TYPE_ERR(val) ((1<<15) | (val))
+#define NBD_REPLY_TYPE_IS_ERR(val) (!!((val) & (1<<15)))
+
+#define NBD_REPLY_TYPE_NONE         0
+#define NBD_REPLY_TYPE_OFFSET_DATA  1
+#define NBD_REPLY_TYPE_OFFSET_HOLE  2
+#define NBD_REPLY_TYPE_BLOCK_STATUS 5
+#define NBD_REPLY_TYPE_ERROR        NBD_REPLY_TYPE_ERR (1)
+#define NBD_REPLY_TYPE_ERROR_OFFSET NBD_REPLY_TYPE_ERR (2)
+
+#define base_allocation_id 1
+
+#define NBD_REP_ACK                  1
+#define NBD_REP_SERVER               2
+#define NBD_REP_INFO                 3
+#define NBD_REP_META_CONTEXT         4
+#define NBD_REP_ERR_UNSUP            NBD_REP_ERR (1)
+#define NBD_REP_ERR_POLICY           NBD_REP_ERR (2)
+#define NBD_REP_ERR_INVALID          NBD_REP_ERR (3)
+#define NBD_REP_ERR_PLATFORM         NBD_REP_ERR (4)
+#define NBD_REP_ERR_TLS_REQD         NBD_REP_ERR (5)
+#define NBD_REP_ERR_UNKNOWN          NBD_REP_ERR (6)
+#define NBD_REP_ERR_SHUTDOWN         NBD_REP_ERR (7)
+#define NBD_REP_ERR_BLOCK_SIZE_REQD  NBD_REP_ERR (8)
+#define NBD_REP_ERR_TOO_BIG          NBD_REP_ERR (9)
+
+struct nbd_fixed_new_option_reply_meta_context {
+  uint32_t context_id;
+} __attribute__((__packed__));
+
+struct nbd_new_handshake {
+  uint64_t nbdmagic;
+  uint64_t version;
+  uint16_t gflags;
+} __attribute__((__packed__));
+
+struct nbd_export_name_option_reply {
+  uint64_t exportsize;
+  uint16_t eflags;
+  char zeroes[124];
+} __attribute__((__packed__));
+
+struct nbd_new_option {
+  uint64_t version;
+  uint32_t option;
+  uint32_t optlen;
+} __attribute__((__packed__));
+
+struct nbd_fixed_new_option_reply {
+  uint64_t magic;
+  uint32_t option;
+  uint32_t reply;
+  uint32_t replylen;
+} __attribute__((__packed__));
+
+struct nbd_fixed_new_option_reply_info_export {
+  uint16_t info;
+  uint64_t exportsize;
+  uint16_t eflags;
+} __attribute__((__packed__));
+
+struct nbd_block_descriptor {
+  uint32_t length;
+  uint32_t status_flags;
+} __attribute__((__packed__));
+
+struct nbd_structured_reply {
+  uint32_t magic;
+  uint16_t flags;
+  uint16_t type;
+  uint64_t handle;
+  uint32_t length;
+} __attribute__((__packed__));
+
+#endif /* _TAPDISK_PROTOCOL_NEW_H_ */
+

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -225,6 +225,10 @@ int tapdisk_vbd_resume(td_vbd_t *, const char *);
 void tapdisk_vbd_kick(td_vbd_t *);
 void tapdisk_vbd_check_state(td_vbd_t *);
 
+void tapdisk_vbd_complete_td_request(td_request_t, int);
+int add_extent(tapdisk_extents_t *, td_request_t *);
+int tapdisk_vbd_issue_request(td_vbd_t *, td_vbd_request_t *);
+
 /**
  * Checks whether there are new requests and if so it submits them, prodived
  * that the queue has not been quiesced.
@@ -237,6 +241,7 @@ void tapdisk_vbd_check_progress(td_vbd_t *);
 void tapdisk_vbd_debug(td_vbd_t *);
 int tapdisk_vbd_start_nbdserver(td_vbd_t *);
 void tapdisk_vbd_stats(td_vbd_t *, td_stats_t *);
+void tapdisk_vbd_complete_block_status_request(td_request_t, int);
 
 /**
  * Tells whether the VBD contains at least one dead ring.

--- a/mockatests/drivers/Makefile.am
+++ b/mockatests/drivers/Makefile.am
@@ -8,8 +8,12 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/drivers -I../include
 check_PROGRAMS = test-drivers
 TESTS = test-drivers
 
-test_drivers_SOURCES = test-drivers.c test-tapdisk-stats.c
+test_drivers_SOURCES = test-drivers.c test-tapdisk-stats.c test-tapdisk-vbd.c vbd-wrappers.c test-tapdisk-nbdserver.c
 test_drivers_LDFLAGS = $(top_srcdir)/drivers/libtapdisk.la -lcmocka -luuid
+test_drivers_LDFLAGS += -Wl,--wrap=tapdisk_image_check_request
+test_drivers_LDFLAGS += -Wl,--wrap=td_queue_block_status
+test_drivers_LDFLAGS += -Wl,--wrap=send
+test_drivers_LDFLAGS += -Wl,--wrap=tapdisk_server_register_event
 
 clean-local:
 	-rm -rf *.gc??

--- a/mockatests/drivers/test-drivers.c
+++ b/mockatests/drivers/test-drivers.c
@@ -39,7 +39,9 @@
 int main(void)
 {
 	int result =
-		cmocka_run_group_tests_name("Stats tests", tapdisk_stats_tests, NULL, NULL);
+		cmocka_run_group_tests_name("Stats tests", tapdisk_stats_tests, NULL, NULL)+
+		cmocka_run_group_tests_name("nbd_server_tests", tapdisk_nbdserver_tests, NULL, NULL)+
+		cmocka_run_group_tests_name("VBD tests", tapdisk_vbd_tests, NULL, NULL);
 
 	return result;
 }

--- a/mockatests/drivers/test-tapdisk-vbd.c
+++ b/mockatests/drivers/test-tapdisk-vbd.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020, Citrix Systems, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+
+#include "test-suites.h"
+#include "tapdisk.h"
+#include "tapdisk-vbd.h"
+#include "tapdisk-disktype.h"
+#include "tapdisk-image.h"
+#include "tapdisk-interface.h"
+
+void
+test_vbd_linked_list(void **state)
+{
+	tapdisk_extents_t extents;
+	bzero(&extents, sizeof(tapdisk_extents_t));
+	td_request_t vreq;
+	bzero(&vreq, sizeof(td_request_t));
+
+	vreq.sec = 0;
+	vreq.secs = 2;
+	vreq.status = 1;
+	
+	add_extent(&extents, &vreq);
+	assert_ptr_equal(extents.tail, extents.head);
+	assert_int_equal(extents.tail->start, 0);
+	assert_int_equal(extents.tail->length, 2);
+	assert_int_equal(extents.tail->flag, 1);
+	assert_null(extents.tail->next);
+	assert_int_equal(extents.count, 1);
+}
+
+void
+test_vbd_issue_request(void **stat)
+{
+
+	td_vbd_t vbd;
+	bzero(&vbd, sizeof(td_vbd_t));
+	INIT_LIST_HEAD(&vbd.images);
+	INIT_LIST_HEAD(&vbd.pending_requests);
+	td_image_t *image = tapdisk_image_allocate("blah", DISK_TYPE_VHD, TD_OPEN_RDONLY | TD_OPEN_SHAREABLE);
+	list_add_tail(&image->next, &vbd.images);
+
+	td_vbd_request_t vreq;
+	bzero(&vreq, sizeof(td_vbd_request_t));
+	INIT_LIST_HEAD(&vreq.next);
+	vreq.iovcnt = 1;
+	struct td_iovec iov;
+	iov.base = 0;
+	iov.secs = 2;
+	vreq.iov = &iov;
+	vreq.op = TD_OP_BLOCK_STATUS;
+
+	td_request_t my_treq;
+	bzero(&my_treq, sizeof(my_treq));
+	my_treq.sidx           = 0;
+	my_treq.buf            = iov.base;
+	my_treq.sec            = vreq.sec;
+	my_treq.secs           = iov.secs;
+	my_treq.image          = image;
+	my_treq.cb_data        = NULL;
+	my_treq.vreq           = &vreq;
+	my_treq.op = TD_OP_BLOCK_STATUS;
+	my_treq.cb = tapdisk_vbd_complete_block_status_request;
+	
+	expect_memory(__wrap_td_queue_block_status, treq, &my_treq, sizeof(my_treq));
+	
+	will_return(__wrap_tapdisk_image_check_request, 0);
+	int err = tapdisk_vbd_issue_request(&vbd, &vreq);
+	assert_int_equal(err, 0);
+	tapdisk_image_free(image);
+}
+
+void
+test_vbd_complete_block_status_request(void **stat)
+{
+
+	td_vbd_t vbd;
+	bzero(&vbd, sizeof(td_vbd_t));
+	INIT_LIST_HEAD(&vbd.images);
+	INIT_LIST_HEAD(&vbd.pending_requests);
+	td_image_t *image = tapdisk_image_allocate("blah", DISK_TYPE_VHD, TD_OPEN_RDONLY | TD_OPEN_SHAREABLE);
+	list_add_tail(&image->next, &vbd.images);
+
+	tapdisk_extents_t extents;
+	bzero(&extents, sizeof(extents));
+	
+	td_vbd_request_t vreq;
+	bzero(&vreq, sizeof(td_vbd_request_t));
+	INIT_LIST_HEAD(&vreq.next);
+	vreq.vbd = &vbd;
+	vreq.iovcnt = 1;
+	struct td_iovec iov;
+	iov.base = 0;
+	iov.secs = 123;
+	vreq.iov = &iov;
+	vreq.op = TD_OP_BLOCK_STATUS;
+	vreq.data = &extents;
+
+	td_request_t my_treq;
+	bzero(&my_treq, sizeof(my_treq));
+	my_treq.sidx           = 0;
+	my_treq.buf            = iov.base;
+	my_treq.sec            = vreq.sec;
+	my_treq.secs           = iov.secs;
+	my_treq.image          = image;
+	my_treq.cb_data        = NULL;
+	my_treq.vreq           = &vreq;
+	my_treq.status	       = TD_BLOCK_STATE_HOLE;
+	my_treq.op = TD_OP_BLOCK_STATUS;
+	my_treq.cb = tapdisk_vbd_complete_block_status_request;
+
+	tapdisk_vbd_complete_block_status_request(my_treq, 0);
+	assert_non_null(extents.head);
+	assert_int_equal(extents.head->flag, TD_BLOCK_STATE_HOLE);
+	assert_int_equal(extents.head->start, my_treq.sec);
+	assert_int_equal(extents.head->length, my_treq.secs);
+}

--- a/mockatests/drivers/vbd-wrappers.c
+++ b/mockatests/drivers/vbd-wrappers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Citrix Systems, Inc.
+ * Copyright (c) 2020, Citrix Systems, Inc.
  *
  * All rights reserved.
  *
@@ -28,39 +28,42 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __TEST_SUITES_H__
-#define __TEST_SUITES_H__
-
+#include <stdarg.h>
+#include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-#include <uuid/uuid.h>
-#include <stdint.h>
 
-void test_stats_normal_buffer(void **state);
-void test_stats_realloc_buffer(void **state);
-void test_stats_realloc_buffer_edgecase(void **state);
+#include "tapdisk.h"
+#include "tapdisk-interface.h"
 
-static const struct CMUnitTest tapdisk_stats_tests[] = {
-	cmocka_unit_test(test_stats_normal_buffer),
-	cmocka_unit_test(test_stats_realloc_buffer),
-	cmocka_unit_test(test_stats_realloc_buffer_edgecase)
-};
+int
+__wrap_tapdisk_image_check_request(td_image_t *image, td_vbd_request_t *vreq)
+{
+	return (int)mock();
+}
 
-void test_vbd_linked_list(void **state);
-void test_vbd_complete_td_request(void **state);
-void test_vbd_issue_request(void **stat);
-void test_vbd_complete_block_status_request(void **stat);
+void
+__wrap_td_queue_block_status(td_image_t *image, td_request_t *treq)
+{
+	check_expected(treq);
+}
 
-static const struct CMUnitTest tapdisk_vbd_tests[] = {
-	cmocka_unit_test(test_vbd_linked_list),
-	cmocka_unit_test(test_vbd_issue_request),
-	cmocka_unit_test(test_vbd_complete_block_status_request)
-};
+int
+__wrap_send(int fd, void* buf, size_t size, int flags)
+{
+	check_expected(buf);
+	check_expected(fd);
+	check_expected(size);
+	check_expected(flags);
+	return (int)mock();
+}
 
-void test_nbdserver_new_protocol_handshake(void **state);
-void test_nbdserver_new_protocol_handshake_send_fails(void **state);
-static const struct CMUnitTest tapdisk_nbdserver_tests[] = {
-	cmocka_unit_test(test_nbdserver_new_protocol_handshake)
-};
+event_id_t
+__wrap_tapdisk_server_register_event(char mode, int fd,
+                              struct timeval timeout, event_cb_t cb, void *data)
+{
+	check_expected(mode);
+	check_expected_ptr(cb);
+	return 0;
+}
 
-#endif /* __TEST_SUITES_H__ */


### PR DESCRIPTION
This commit implements a minimal set of options for CH use cases. The following scenarios have been tested.

	1) blktap -> blktap (SXM)
	2) blktap -> qemu (VM boot)
	3) blktap -> nbclient (vdi-copy)
	4) blktap -> python-nbd-client (sparse-dd)

Unfortunately, we need to maintain the old handshake for SXM backwards compatibility. Thus the new protocol is
deactivated by default pending tap-ctl changes to toggle handshake protocol.

This has been passed through the storage BST twice both with new and old protocols.

Suite run 141670 -> New protocol turned on.
Suite run 141696 -> New protocol turned off.
