### PR TITLE
CA-349971: use correct return type for memcmp

### DIFF
--- a/vhd/lib/vhd-util-check.c
+++ b/vhd/lib/vhd-util-check.c
@@ -614,7 +614,8 @@ check_backup:
 		    !strncmp(backup.crtr_app, "tap", 3) &&
 		    (backup.crtr_ver == VHD_VERSION(0, 1) ||
 		     backup.crtr_ver == VHD_VERSION(1, 1))) {
-			char cmp, tmp = backup.hidden;
+			int cmp;
+			char tmp = backup.hidden;
 			backup.hidden = 0;
 			cmp = memcmp(&primary, &backup, sizeof(primary));
 			backup.hidden = tmp;


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>