### PR TITLE
CA-35250 - Fix Coverity issues introduced by CP-32853

### DIFF
--- a/drivers/io-backend.h
+++ b/drivers/io-backend.h
@@ -31,16 +31,24 @@
 #ifndef IO_BACKEND_H
 #define IO_BACKEND_H
 
+#include <aio.h>
+#include <libaio.h>
+
 struct tiocb;
 struct tfilter;
 typedef void* tqueue;
 typedef void (*td_queue_callback_t)(void *arg, struct tiocb *, int err);
 
+union uioc {
+	struct aiocb aio;
+	struct iocb io;
+};
+
 struct tiocb {
 	td_queue_callback_t   cb;
 	void                 *arg;
 
-        void		     *iocb;
+        union uioc	      uiocb;
 	struct tiocb         *next;
 };
 


### PR DESCRIPTION
Running this through a BST. I will remove the do not merge if reviewers are happy and the BST succeeds.

I used a union to avoid the malloc and void* (Coverity complained that the malloc could fail and we'd have a NULL pointer) Propagating a failure in malloc would have meant changing function interfaces in many files and very error prone. 