### PR TITLE
Reset TD_VBD_LOG_DROPPED flag when VBD watchdog is cleared

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1107,6 +1107,7 @@ void watchdog_cleared(td_vbd_t *vbd)
 		DBG(TLOG_WARN, "%s: watchdog timeout: requests were blocked\n", vbd->name);
 		/* Ideally want a direct way to flush the log */
 		tlog_precious(1);
+		td_flag_clear(vbd->state, TD_VBD_LOG_DROPPED);
 	}
 	vbd->watchdog_warned = false;
 }


### PR DESCRIPTION
The `TD_VBD_LOG_DROPPED` flag is never reset when the VBD watchdog is cleared. On some configurations, the stats are no longer accessible because of that. 

Also I think it's necessary to add a patch here: https://github.com/xenserver/rrdd-plugins/blob/c120f5d8610947e80932c76ece0b27d393a60260/src/rrdp-iostat/rrdp_iostat.ml#L301 because when `tap-ctl list` is called, the `TD_VBD_LOG_DROPPED` flag is written like this:

```
13877   28 0x100        vhd /var/run/sr-mount/97102065-3d6b-550c-c8e8-fe10a0b0c697/e199bf69-3090-4ffd-b352-0d6a2249126e.vhd
```

The `0x100` stated is never matched by the regex because `number` is defined like this: https://github.com/xenserver/rrdd-plugins/blob/c120f5d8610947e80932c76ece0b27d393a60260/src/rrdp-iostat/rrdp_iostat.ml#L123

For more information: https://xcp-ng.org/forum/topic/4563/missing-i-o-statistics-after-ha-nfs-sr-failover?_=1620378469043