### PR TITLE
CA-353265 Disable posix AIO backend

### DIFF
--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -784,7 +784,7 @@ tapdisk_server_complete(void)
 {
 	int err;
 	server.rw_backend = get_libaio_backend();
-	server.ro_backend = get_posix_aio_backend();
+	server.ro_backend = get_libaio_backend();
 
 	server.rw_backend = get_libaio_backend();
 	err = tapdisk_server_init_aio();


### PR DESCRIPTION
The POSIX AIO backend has some issues. While addressing them it would be good
to make some other alterations as well, so for now just redirect to the libaio
backend.

Signed-off-by: Tim Smith <tim.smith@citrix.com>