### PR TITLE
include sys/sysmacros.h

### DIFF
--- a/control/tap-ctl-allocate.c
+++ b/control/tap-ctl-allocate.c
@@ -42,6 +42,7 @@
 #include <libgen.h>
 #include <sys/file.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <linux/major.h>

--- a/drivers/tapdisk-blktap.c
+++ b/drivers/tapdisk-blktap.c
@@ -40,6 +40,7 @@
 #include <limits.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -48,6 +48,7 @@
 #include <stdarg.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
 #include "debug.h"


### PR DESCRIPTION
glibc moved the declarations of major, minor and makedev from
sys/types.h to sys/sysmacros.h, so make the change.  sys/types.h is left
for backwards compatibility.  Fixes:

libvhd.c:144:9: error: implicit declaration of function 'makedev' [-Werror=implicit-function-declaration]
libvhd.c:156:33: error: implicit declaration of function 'major' [-Werror=implicit-function-declaration]
libvhd.c:172:64: error: implicit declaration of function 'minor' [-Werror=implicit-function-declaration]

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>