### PR TITLE
Set libvhdio libtool -version-info

### DIFF
--- a/part/vhdpartx
+++ b/part/vhdpartx
@@ -30,7 +30,7 @@
 set -e
 
 PARTUTIL=/usr/sbin/part-util
-LIBVHDIO=/usr/lib/libvhdio.so.1.0
+LIBVHDIO=/usr/lib/libvhdio.so.0.1.1
 
 die()
 {

--- a/vhd/lib/Makefile.am
+++ b/vhd/lib/Makefile.am
@@ -47,7 +47,7 @@ libvhd_la_LIBADD = -luuid -ldl $(LIBICONV)  $(top_srcdir)/lvm/liblvmutil.la
 libvhdio_la_SOURCES  = libvhdio.c
 libvhdio_la_SOURCES += ../../part/partition.c
 
-libvhdio_la_LDFLAGS  = -release $(VERSION)
+libvhdio_la_LDFLAGS  = -version-info 1:1:1
 libvhdio_la_LDFLAGS += -shared
 
 libvhdio_la_LIBADD  = libvhd.la


### PR DESCRIPTION
commit 4d811725ca5c "ctl/vhd: Add libtool -version-info." changed libvhd
and libblktapctl to use -version-info because:

"""
    Using -release is cheap, but results in hardcoded version dependencies
    which is evil.

    We start out with 1:1:1 for both libvhd and libblktapctl.That is,
    e.g. libvhd.so.0.1.1:
     - Second interface generation.
     - Second revision.
     - All imaginary prior ones supported.
"""

However it did not change libvhdio.  Do it now.  This quiets an
OpenEmbedded complaint about the library when packaging it.

Also update vhdpartx so the library can be found.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>