### PR TITLE
fdreceiver: Don't assert when not passed an FD

### DIFF
--- a/drivers/tapdisk-fdreceiver.c
+++ b/drivers/tapdisk-fdreceiver.c
@@ -121,7 +121,9 @@ td_fdreceiver_recv_fd(event_id_t id, char mode, void *data)
 	 * It is the responsibility of this callback function to arrange that
 	 * the fd is eventually closed
 	 */
-	fdreceiver->callback(fd, iobuf, fdreceiver->callback_data);
+	if (fd >= 0) {
+		fdreceiver->callback(fd, iobuf, fdreceiver->callback_data);
+	}
 out:
 	free(iobuf);
 }


### PR DESCRIPTION
The fdreceiver callbacks like tapdisk_nbdserver_fdreceiver_cb() will
assert when passed an invalid FD.  This will take out a potentially
active tapdisk process.

Have the higher level callback handler skip calling the callback when
there is no FD.  The lack of activity can be inferred from the earlier
printing of FD as -1.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>