### PR TITLE
Fix new style nbdserver support

### DIFF
--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -825,7 +825,7 @@ tapdisk_nbdserver_handshake_cb(event_id_t id, char mode, void *data)
 	}
 }
 
-static void
+void
 tapdisk_nbdserver_newclient_fd_new_fixed(td_nbdserver_t *server, int new_fd)
 {
 	ASSERT(server);

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -1026,12 +1026,8 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 
 		break;
 	case TAPDISK_NBD_CMD_DISC:
-		INFO("Received close message. Sending reconnect "
-				"header");
+		INFO("Received close message - closing connection");
 		tapdisk_nbdserver_free_client(client);
-		INFO("About to send initial connection message");
-		tapdisk_nbdserver_newclient_fd(server, fd);
-		INFO("Sent initial connection message");
 		return;
 	case TAPDISK_NBD_CMD_BLOCK_STATUS:
 	{

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -427,7 +427,15 @@ receive_newstyle_options(td_nbdserver_t *server, int new_fd, bool no_zeroes)
 		case NBD_OPT_GO:
 		{   
 			uint16_t flags;
-			INFO("Processing NBD_OPT_EXORT_NAME");
+			INFO("Processing NBD_OPT_GO");
+
+			if(receive_info(new_fd, (char *)buf, opt_len) == -1){
+				ERR ("Failed to received data for NBD_OPT_GO");
+				ret = -1;
+				goto done;
+			}
+			buf[opt_len] = '\0';
+			INFO("Exportname \"%s\"", buf);
 
 			provide_server_info(server, &exportsize, &flags);
 	

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -1367,7 +1367,7 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 	if (new_fd == -1) {
 		err = -errno;
 		ERR("failed to create UNIX domain socket: %s\n", strerror(-err));
-		goto out;
+		goto out_no_fd;
 	}
 
 	server->local.sun_family = AF_UNIX;
@@ -1403,6 +1403,7 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 		goto out;
 	}
 
+	server->unix_listening_fd = new_fd;
 	err = tapdisk_nbdserver_unpause_unix(server);
 	if (err) {
 		ERR("failed to unpause the NBD server (unix): %s\n",
@@ -1413,11 +1414,13 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 	INFO("Successfully started NBD server on %s\n", server->sockpath);
 
 out:
-	if (err && (new_fd != -1)) {
+	if (err) {
 		close(new_fd);
-	} else {
-		server->unix_listening_fd = new_fd;
+		server->unix_listening_fd = -1;
 	}
+
+out_no_fd:
+
 	return err;
 }
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -388,7 +388,7 @@ receive_newstyle_options(td_nbdserver_t *server, int new_fd, bool no_zeroes)
 		switch (opt_code) {
 		case NBD_OPT_EXPORT_NAME:
 		{
-			INFO("Processing NBD_OPT_EXORT_NAME");
+			INFO("Processing NBD_OPT_EXPORT_NAME");
 			uint16_t flags = 0;
 			if(receive_info(new_fd, (char *)buf, opt_len) == -1){
 				ERR ("Failed to received data for NBD_OPT_EXPORT_NAME");
@@ -396,7 +396,7 @@ receive_newstyle_options(td_nbdserver_t *server, int new_fd, bool no_zeroes)
 				goto done;
 			}
 			buf[opt_len] = '\0';
-			INFO("Exportname %s", buf);
+			INFO("Exportname \"%s\"", buf);
 
 			provide_server_info(server, &exportsize, &flags);
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -977,7 +977,8 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 	}
 
 	if (request.magic != htonl(NBD_REQUEST_MAGIC)) {
-		ERR("Not enough magic");
+		ERR("Not enough magic expected %08x got %08x",
+		    NBD_REQUEST_MAGIC, ntohl(request.magic));
 		goto fail;
 	}
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -667,6 +667,9 @@ tapdisk_nbdserver_free_client(td_nbdserver_client_t *client)
 	if (client->client_event_id >= 0)
 		tapdisk_nbdserver_disable_client(client);
 
+	close(client->client_fd);
+	client->client_fd = -1;
+
 	if (likely(!tapdisk_nbdserver_reqs_pending(client))) {
 		list_del(&client->clientlist);
 		tapdisk_nbdserver_reqs_free(client);

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -98,11 +98,6 @@ struct td_nbdserver {
 	int                     unix_listening_fd;
 
 	/**
-	 * Socket opened during handshake negotiation.
-	 */
-	int                     handshake_fd;
-
-	/**
 	 * Event ID for the file descriptor receiver.
 	 */
 	int                     unix_listening_event_id;

--- a/drivers/tapdisk-nbdserver.h
+++ b/drivers/tapdisk-nbdserver.h
@@ -182,7 +182,7 @@ void tapdisk_nbdserver_free_request(td_nbdserver_client_t *client,
  */
 int tapdisk_nbdserver_reqs_pending(td_nbdserver_client_t *client);
 
-int tapdisk_nbdserver_new_protocol_handshake(td_nbdserver_t*, int);
+void tapdisk_nbdserver_newclient_fd_new_fixed(td_nbdserver_t*, int);
 void tapdisk_nbdserver_handshake_cb(event_id_t, char, void*);
 
 #endif /* _TAPDISK_NBDSERVER_H_ */

--- a/mockatests/drivers/Makefile.am
+++ b/mockatests/drivers/Makefile.am
@@ -14,6 +14,7 @@ test_drivers_LDFLAGS += -Wl,--wrap=tapdisk_image_check_request
 test_drivers_LDFLAGS += -Wl,--wrap=td_queue_block_status
 test_drivers_LDFLAGS += -Wl,--wrap=send
 test_drivers_LDFLAGS += -Wl,--wrap=tapdisk_server_register_event
+test_drivers_LDFLAGS += -Wl,--wrap=tapdisk_vsyslog
 
 clean-local:
 	-rm -rf *.gc??

--- a/mockatests/drivers/test-suites.h
+++ b/mockatests/drivers/test-suites.h
@@ -57,10 +57,10 @@ static const struct CMUnitTest tapdisk_vbd_tests[] = {
 	cmocka_unit_test(test_vbd_complete_block_status_request)
 };
 
-void test_nbdserver_new_protocol_handshake(void **state);
-void test_nbdserver_new_protocol_handshake_send_fails(void **state);
+void test_nbdserver_newclient_fd_new_fixed(void **state);
+void test_nbdserver_newclient_fd_new_fixed_send_fails(void **state);
 static const struct CMUnitTest tapdisk_nbdserver_tests[] = {
-	cmocka_unit_test(test_nbdserver_new_protocol_handshake)
+	cmocka_unit_test(test_nbdserver_newclient_fd_new_fixed)
 };
 
 #endif /* __TEST_SUITES_H__ */


### PR DESCRIPTION
These patches get nbd-client to be able to connect to tapdisk's nbdserver in new style mode.  nbd-client dropped old style support, so it cannot connect to the existing nbdserver.  To test this, I patched drivers/tapdisk-nbdserver.c to set `SERVER_USE_OLD_PROTOCOL = 0`.

`nbd-client -unix /run/blktap-control/nbd$PID.$MINOR /dev/nbd0` now connects (with SERVER_USE_OLD_PROTOCOL = 0).