### PR TITLE
GCC 11.2 compile fixes

### DIFF
--- a/cpumond/cpumond.c
+++ b/cpumond/cpumond.c
@@ -120,7 +120,7 @@ err:
     return NULL;
 }
 
-inline int statread(int statfd, long long *total, long long *idle){
+static int statread(int statfd, long long *total, long long *idle){
     long long val[10];
     char      buf[256];
     int       i, err = 0;

--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -882,8 +882,8 @@ _vhd_open(td_driver_t *driver, const char *name,
 			      VHD_FLAG_OPEN_QUIET  |
 			      VHD_FLAG_OPEN_RDONLY |
 			      VHD_FLAG_OPEN_NO_CACHE);
-    if (flags & TD_OPEN_LOCAL_CACHE)
-        vhd_flags |= VHD_FLAG_OPEN_LOCAL_CACHE;
+	if (flags & TD_OPEN_LOCAL_CACHE)
+		vhd_flags |= VHD_FLAG_OPEN_LOCAL_CACHE;
 
 	/* pre-allocate for all but NFS and LVM storage */
 	driver->storage = tapdisk_storage_type(name);

--- a/drivers/tapdisk-blktap.c
+++ b/drivers/tapdisk-blktap.c
@@ -80,7 +80,7 @@ static void __tapdisk_blktap_close(td_blktap_t *);
 struct td_blktap_req {
 	td_vbd_request_t        vreq;
 	unsigned int            id;
-	char                    name[16];
+	char                    name[27];
 	struct td_iovec         iov[BLKTAP_SEGMENT_MAX];
         struct timeval          ts;
 };

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -978,8 +978,8 @@ tapdisk_control_close_image(struct tapdisk_ctl_conn *conn,
 
 out:
 	response->cookie = request->cookie;
-    if (!err)
-        response->type = TAPDISK_MESSAGE_CLOSE_RSP;
+	if (!err)
+		response->type = TAPDISK_MESSAGE_CLOSE_RSP;
 	return err;
 }
 

--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -440,7 +440,7 @@ out:
 
 const long long USEC_PER_SEC = 1000000L;
 
-inline long long timeval_to_us(struct timeval *tv)
+long long timeval_to_us(struct timeval *tv)
 {
 	return ((long long)tv->tv_sec * USEC_PER_SEC) + tv->tv_usec;
 }

--- a/drivers/tapdisk-utils.h
+++ b/drivers/tapdisk-utils.h
@@ -100,6 +100,6 @@ shm_create(struct shm *shm);
 int
 shm_destroy(struct shm *shm);
 
-inline long long timeval_to_us(struct timeval *tv);
+long long timeval_to_us(struct timeval *tv);
 
 #endif

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1879,7 +1879,7 @@ tapdisk_vbd_stats(td_vbd_t *vbd, td_stats_t *st)
 }
 
 
-bool inline
+bool
 tapdisk_vbd_contains_dead_rings(td_vbd_t * vbd)
 {
     return !list_empty(&vbd->dead_rings);

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -638,13 +638,13 @@ tapdisk_vbd_open_vdi(td_vbd_t *vbd, const char *name, td_flag_t flags, int prt_d
 		}
 	}
 
-    err = vbd_stats_create(vbd);
-    if (err)
-        goto fail;
+	err = vbd_stats_create(vbd);
+	if (err)
+		goto fail;
 
-    err = td_metrics_vdi_start(vbd->tap->minor, &vbd->vdi_stats);
-    if (err)
-        goto fail;
+	err = td_metrics_vdi_start(vbd->tap->minor, &vbd->vdi_stats);
+	if (err)
+		goto fail;
 	if (tmp != vbd->name)
 		free(tmp);
 

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -246,5 +246,5 @@ void tapdisk_vbd_complete_block_status_request(td_request_t, int);
 /**
  * Tells whether the VBD contains at least one dead ring.
  */
-bool inline tapdisk_vbd_contains_dead_rings(td_vbd_t * vbd);
+bool tapdisk_vbd_contains_dead_rings(td_vbd_t * vbd);
 #endif

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -627,21 +627,21 @@ fail:
 }
 
 
-inline event_id_t
+event_id_t
 tapdisk_xenblkif_evtchn_event_id(const struct td_xenblkif *blkif)
 {
 	return blkif->ctx->ring_event;
 }
 
 
-inline event_id_t
+event_id_t
 tapdisk_xenblkif_chkrng_event_id(const struct td_xenblkif *blkif)
 {
 	return blkif->chkrng_event;
 }
 
 
-inline event_id_t
+event_id_t
 tapdisk_xenblkif_stoppolling_event_id(const struct td_xenblkif *blkif)
 {
 	return blkif->stoppolling_event;

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -585,15 +585,15 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
 	td_blkif->chkrng_event = tapdisk_server_register_event(
 			SCHEDULER_POLL_TIMEOUT,	-1, TV_INF,
 			tapdisk_xenblkif_cb_chkrng, td_blkif);
-    if (unlikely(td_blkif->chkrng_event < 0)) {
-        err = td_blkif->chkrng_event;
-        RING_ERR(td_blkif, "failed to register event: %s\n", strerror(-err));
-        goto fail;
-    }
+	if (unlikely(td_blkif->chkrng_event < 0)) {
+		err = td_blkif->chkrng_event;
+		RING_ERR(td_blkif, "failed to register event: %s\n", strerror(-err));
+		goto fail;
+	}
 
-    err = td_metrics_vbd_start(td_blkif->domid, td_blkif->devid, &td_blkif->vbd_stats);
-    if (unlikely(err))
-        goto fail;
+	err = td_metrics_vbd_start(td_blkif->domid, td_blkif->devid, &td_blkif->vbd_stats);
+	if (unlikely(err))
+		goto fail;
 
 	td_blkif->stoppolling_event = tapdisk_server_register_event(
 			SCHEDULER_POLL_TIMEOUT,	-1, TV_INF,

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -270,21 +270,21 @@ tapdisk_xenblkif_find(const domid_t domid, const int devid);
  * channel can be shared by multiple block interfaces, the event ID will be
  * shared as well.
  */
-extern inline event_id_t
+extern event_id_t
 tapdisk_xenblkif_evtchn_event_id(const struct td_xenblkif *blkif);
 
 /**
  * Returns the event ID associated wit checking the ring. This is a private
  * event.
  */
-extern inline event_id_t
+extern event_id_t
 tapdisk_xenblkif_chkrng_event_id(const struct td_xenblkif * const blkif);
 
 /**
  * Returns the event ID associated with stopping polling. This is a private
  * event.
  */
-extern inline event_id_t
+extern event_id_t
 tapdisk_xenblkif_stoppolling_event_id(const struct td_xenblkif * const blkif);
 
 /**

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -453,16 +453,16 @@ out:
  */
 void
 tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
-        struct td_xenblkif_req* tapreq, int err, const int final)
+		struct td_xenblkif_req* tapreq, int err, const int final)
 {
 	int _err;
-    long long *max = NULL, *sum = NULL, *cnt = NULL;
+	long long *max = NULL, *sum = NULL, *cnt = NULL;
 	static int depth = 0;
 	bool processing_barrier_message;
-    uint64_t *ticks = NULL;
+	uint64_t *ticks = NULL;
 
-    ASSERT(blkif);
-    ASSERT(tapreq);
+	ASSERT(blkif);
+	ASSERT(tapreq);
 	ASSERT(depth >= 0);
 
 	depth++;
@@ -525,7 +525,7 @@ tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
 			long long interval;
 			gettimeofday(&now, NULL);
 			interval = timeval_to_us(&now) - timeval_to_us(&tapreq->ts);
-                       *ticks += interval;
+			*ticks += interval;
 			if (interval > *max)
 				*max = interval;
 
@@ -534,23 +534,23 @@ tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
 		}
 
 		if (likely(err == 0))
-            _err = BLKIF_RSP_OKAY;
+			_err = BLKIF_RSP_OKAY;
 		else
-            _err = BLKIF_RSP_ERROR;
+			_err = BLKIF_RSP_ERROR;
 
 		xenio_blkif_put_response(blkif, tapreq, _err, final);
 	}
 
-    tapdisk_xenblkif_free_request(blkif, tapreq);
+	tapdisk_xenblkif_free_request(blkif, tapreq);
 
-    blkif->stats.reqs.out++;
-    if (final)
-        blkif->stats.kicks.out++;
+	blkif->stats.reqs.out++;
+	if (final)
+		blkif->stats.kicks.out++;
 
 	if (unlikely(processing_barrier_message))
 		blkif->barrier.msg = NULL;
 
-    /*
+	/*
 	 * Schedule a ring check in case we left requests in it due to lack of
 	 * memory or in case we stopped processing it because of a barrier.
 	 *

--- a/mockatests/wrappers/wrappers.c
+++ b/mockatests/wrappers/wrappers.c
@@ -96,7 +96,7 @@ int
 __wrap_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	if (mock_fwrite) {
-		struct fwrite_data *data = mock();
+		struct fwrite_data *data = (struct fwrite_data *)mock();
 
 		size_t remaining = data->size - data->offset;
 		size_t len = size * nmemb;
@@ -142,7 +142,7 @@ int
 wrap_vprintf(const char *format, va_list ap)
 {
 	if (mock_vprintf) {
-		struct printf_data *data = mock();
+		struct printf_data *data = (struct printf_data *)mock();
 		int remaining = data->size - data->offset;
 		int len = vsnprintf(data->buf + data->offset, remaining, format, ap);
 		assert_in_range(len, 0, remaining);

--- a/mockatests/wrappers/wrappers.c
+++ b/mockatests/wrappers/wrappers.c
@@ -96,7 +96,7 @@ int
 __wrap_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	if (mock_fwrite) {
-		struct fwrite_data *data = (struct fwrite_data *)mock();
+		struct fwrite_data *data = mock_ptr_type(struct fwrite_data *);
 
 		size_t remaining = data->size - data->offset;
 		size_t len = size * nmemb;

--- a/vhd/lib/vhd-util-copy.c
+++ b/vhd/lib/vhd-util-copy.c
@@ -53,10 +53,10 @@ typedef int (*vhd_open_crypto)(vhd_context_t *, const uint8_t *, size_t,
 typedef int (*vhd_crypto_encrypt_block)(vhd_context_t *, uint64_t,
 					uint8_t *, uint8_t *,
 					unsigned int);
-vhd_calculate_keyhash pvhd_calculate_keyhash;
-vhd_open_crypto pvhd_open_crypto;
-vhd_crypto_encrypt_block pvhd_crypto_encrypt_block;
-void *crypto_handle;
+static vhd_calculate_keyhash pvhd_calculate_keyhash;
+static vhd_open_crypto pvhd_open_crypto;
+static vhd_crypto_encrypt_block pvhd_crypto_encrypt_block;
+static void *crypto_handle;
 
 static int
 __load_crypto()

--- a/vhd/lib/vhd-util-key.c
+++ b/vhd/lib/vhd-util-key.c
@@ -51,8 +51,8 @@ int CRYPTO_SUPPORTED_KEYSIZE[] = { 512, 256, -1};
 
 typedef int (*vhd_calculate_keyhash)(struct vhd_keyhash *keyhash,
 				     const uint8_t *key, size_t key_byte);
-vhd_calculate_keyhash pvhd_calculate_keyhash;
-void *crypto_handle;
+static vhd_calculate_keyhash pvhd_calculate_keyhash;
+static void *crypto_handle;
 
 static int
 __load_crypto()

--- a/vhd/lib/vhd-util-read.c
+++ b/vhd/lib/vhd-util-read.c
@@ -42,7 +42,7 @@
 #include "libvhd.h"
 #include "vhd-util.h"
 
-#define nsize     15
+#define nsize     21
 static char nbuf[nsize];
 
 static inline char *


### PR DESCRIPTION
This series is assorted compilation fixes for GCC 11.2 (Fedora 35).