### PR TITLE
Fix a block of newly detected Coverity issues

### DIFF
--- a/control/tap-ctl-ipc.c
+++ b/control/tap-ctl-ipc.c
@@ -46,6 +46,7 @@
 #include "tap-ctl.h"
 #include "blktap2.h"
 #include "compiler.h"
+#include "util.h"
 
 int tap_ctl_debug = 0;
 
@@ -253,8 +254,7 @@ tap_ctl_connect(const char *name, int *sfd)
 		return -ENAMETOOLONG;
 	}
 
-	strncpy(saddr.sun_path, name, sizeof(saddr.sun_path));
-	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
+	safe_strncpy(saddr.sun_path, name, sizeof(saddr.sun_path));
 
 	err = connect(fd, (const struct sockaddr *)&saddr, sizeof(saddr));
 	if (err) {

--- a/control/tap-ctl-ipc.c
+++ b/control/tap-ctl-ipc.c
@@ -253,7 +253,8 @@ tap_ctl_connect(const char *name, int *sfd)
 		return -ENAMETOOLONG;
 	}
 
-	strcpy(saddr.sun_path, name);
+	strncpy(saddr.sun_path, name, sizeof(saddr.sun_path));
+	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
 
 	err = connect(fd, (const struct sockaddr *)&saddr, sizeof(saddr));
 	if (err) {

--- a/control/tap-ctl-unpause.c
+++ b/control/tap-ctl-unpause.c
@@ -59,8 +59,8 @@ tap_ctl_unpause(const int id, const int minor, const char *params, int flags,
 			     sizeof(message.u.params.path));
 	if (secondary) {
 		err = snprintf(message.u.params.secondary,
-				sizeof(message.u.params.secondary) - 1, "%s",
-				secondary);
+			       sizeof(message.u.params.secondary), "%s",
+			       secondary);
 		if (err >= sizeof(message.u.params.secondary)) {
 			EPRINTF("secondary image name too long\n");
 			return -ENAMETOOLONG;

--- a/control/tap-ctl-unpause.c
+++ b/control/tap-ctl-unpause.c
@@ -40,6 +40,7 @@
 #include <getopt.h>
 
 #include "tap-ctl.h"
+#include "util.h"
 
 int
 tap_ctl_unpause(const int id, const int minor, const char *params, int flags,
@@ -54,8 +55,8 @@ tap_ctl_unpause(const int id, const int minor, const char *params, int flags,
 	message.u.params.flags = flags;
 
 	if (params)
-		strncpy(message.u.params.path, params,
-				sizeof(message.u.params.path) - 1);
+		safe_strncpy(message.u.params.path, params,
+			     sizeof(message.u.params.path));
 	if (secondary) {
 		err = snprintf(message.u.params.secondary,
 				sizeof(message.u.params.secondary) - 1, "%s",

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -75,7 +75,8 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
             EPRINTF("pool name too long: %s\n", pool);
             return -ENAMETOOLONG;
         }
-        strcpy(message.u.blkif.pool, pool);
+        strncpy(message.u.blkif.pool, pool, sizeof(message.u.blkif.pool));
+        message.u.blkif.pool[sizeof(message.u.blkif.pool) - 1] = '\0';
     } else {
         message.u.blkif.pool[0] = 0;
     }

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -47,6 +47,7 @@
 
 #include "tap-ctl.h"
 #include "compiler.h"
+#include "util.h"
 
 int
 tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, int poll_duration,
@@ -75,8 +76,7 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
             EPRINTF("pool name too long: %s\n", pool);
             return -ENAMETOOLONG;
         }
-        strncpy(message.u.blkif.pool, pool, sizeof(message.u.blkif.pool));
-        message.u.blkif.pool[sizeof(message.u.blkif.pool) - 1] = '\0';
+        safe_strncpy(message.u.blkif.pool, pool, sizeof(message.u.blkif.pool));
     } else {
         message.u.blkif.pool[0] = 0;
     }

--- a/drivers/block-crypto.c
+++ b/drivers/block-crypto.c
@@ -140,11 +140,11 @@ find_keyfile(char **keyfile, const char *dirs,
 		sep = strchr(dirs, ',');
 		/* get directory element */
 		if (sep == NULL) {
-			strncpy(keydir, dirs, sizeof(keydir));
+			safe_strncpy(keydir, dirs, sizeof(keydir));
 			dirs = NULL;
 		} else {
 			size_t len = sep - dirs;
-			strncpy(keydir, dirs, len);
+			safe_strncpy(keydir, dirs, len);
 			dirs = sep+1;
 		}
 

--- a/drivers/block-nbd.c
+++ b/drivers/block-nbd.c
@@ -51,6 +51,7 @@
 #include "timeout-math.h"
 #include "tapdisk-nbdserver.h"
 #include "tapdisk-protocol-new.h"
+#include "util.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -199,9 +200,8 @@ tdnbd_stash_passed_fd(int fd, char *msg, void *data)
 		close(passed_fds[free_index].fd);
 
 	passed_fds[free_index].fd = fd;
-	strncpy(passed_fds[free_index].id, msg,
-		sizeof(passed_fds[free_index].id) - 1);
-	passed_fds[free_index].id[sizeof(passed_fds[free_index].id) - 1] = '\0';
+	safe_strncpy(passed_fds[free_index].id, msg,
+		     sizeof(passed_fds[free_index].id));
 }
 
 static int
@@ -921,8 +921,7 @@ tdnbd_open(td_driver_t* driver, const char* name,
 			return -1;
 		}
 		prv->remote_un.sun_family = AF_UNIX;
-		strncpy(prv->remote_un.sun_path, name, sizeof(prv->remote_un.sun_path));
-		prv->remote_un.sun_path[sizeof(prv->remote_un.sun_path) - 1] = '\0';
+		safe_strncpy(prv->remote_un.sun_path, name, sizeof(prv->remote_un.sun_path));
 		len = strlen(prv->remote_un.sun_path)
 			+ sizeof(prv->remote_un.sun_family);
 		if ((rc = connect(prv->socket, (struct sockaddr*)&prv->remote_un, len)

--- a/drivers/block-nbd.c
+++ b/drivers/block-nbd.c
@@ -921,7 +921,8 @@ tdnbd_open(td_driver_t* driver, const char* name,
 			return -1;
 		}
 		prv->remote_un.sun_family = AF_UNIX;
-		strcpy(prv->remote_un.sun_path, name);
+		strncpy(prv->remote_un.sun_path, name, sizeof(prv->remote_un.sun_path));
+		prv->remote_un.sun_path[sizeof(prv->remote_un.sun_path) - 1] = '\0';
 		len = strlen(prv->remote_un.sun_path)
 			+ sizeof(prv->remote_un.sun_family);
 		if ((rc = connect(prv->socket, (struct sockaddr*)&prv->remote_un, len)
@@ -937,12 +938,11 @@ tdnbd_open(td_driver_t* driver, const char* name,
 	} else {
 		rc = sscanf(name, "%255[^:]:%d", peer_ip, &port);
 		if (rc == 2) {
-			prv->peer_ip = malloc(strlen(peer_ip) + 1);
+			prv->peer_ip = strdup(peer_ip);
 			if (!prv->peer_ip) {
 				ERROR("Failure to malloc for NBD destination");
 				return -1;
 			}
-			strcpy(prv->peer_ip, peer_ip);
 			prv->port = port;
 			prv->name = NULL;
 			INFO("Export peer=%s port=%d\n", prv->peer_ip, prv->port);

--- a/drivers/block-valve.c
+++ b/drivers/block-valve.c
@@ -232,8 +232,7 @@ valve_sock_open(td_valve_t *valve)
 			err = -ENAMETOOLONG;
 			goto fail;
 		}
-		strncpy(addr.sun_path, valve->brname, sizeof(addr.sun_path));
-		addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
+		safe_strncpy(addr.sun_path, valve->brname, sizeof(addr.sun_path));
 	} else
 		snprintf(addr.sun_path, sizeof(addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, valve->brname);

--- a/drivers/block-valve.c
+++ b/drivers/block-valve.c
@@ -232,7 +232,8 @@ valve_sock_open(td_valve_t *valve)
 			err = -ENAMETOOLONG;
 			goto fail;
 		}
-		strcpy(addr.sun_path, valve->brname);
+		strncpy(addr.sun_path, valve->brname, sizeof(addr.sun_path));
+		addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 	} else
 		snprintf(addr.sun_path, sizeof(addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, valve->brname);

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1624,7 +1624,8 @@ tapdisk_control_create_socket(char **socket_path)
 		err = ENAMETOOLONG;
 		goto fail;
 	}
-	strcpy(saddr.sun_path, td_control.path);
+	strncpy(saddr.sun_path, td_control.path, sizeof(saddr.sun_path));
+	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
 
 	saddr.sun_family = AF_UNIX;
 

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -61,6 +61,7 @@
 #include "tapdisk-nbdserver.h"
 #include "td-blkif.h"
 #include "timeout-math.h"
+#include "util.h"
 
 #define TD_CTL_MAX_CONNECTIONS  10
 #define TD_CTL_SOCK_BACKLOG     32
@@ -573,8 +574,8 @@ tapdisk_control_list(struct tapdisk_ctl_conn *conn,
 		response->u.list.path[0] = 0;
 
 		if (vbd->name)
-			strncpy(response->u.list.path, vbd->name,
-				sizeof(response->u.list.path));
+			safe_strncpy(response->u.list.path, vbd->name,
+				     sizeof(response->u.list.path));
 
 		tapdisk_control_write_message(conn, response);
 	}
@@ -1624,8 +1625,7 @@ tapdisk_control_create_socket(char **socket_path)
 		err = ENAMETOOLONG;
 		goto fail;
 	}
-	strncpy(saddr.sun_path, td_control.path, sizeof(saddr.sun_path));
-	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
+	safe_strncpy(saddr.sun_path, td_control.path, sizeof(saddr.sun_path));
 
 	saddr.sun_family = AF_UNIX;
 

--- a/drivers/tapdisk-disktype.c
+++ b/drivers/tapdisk-disktype.c
@@ -248,7 +248,7 @@ tapdisk_disktype_parse_params(const char *params, const char **_path)
 		return -ENAMETOOLONG;
 
 	memset(name, 0, sizeof(name));
-	strncpy(name, params, len);
+	safe_strncpy(name, params, len);
 
 	type = tapdisk_disktype_find(name);
 

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -1379,7 +1379,8 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 		goto out;
 	}
 
-	strcpy(server->local.sun_path, server->sockpath);
+	strncpy(server->local.sun_path, server->sockpath, sizeof(server->local.sun_path));
+	server->local.sun_path[sizeof(server->local.sun_path) - 1] = '\0';
 	err = unlink(server->local.sun_path);
 	if (err == -1 && errno != ENOENT) {
 		err = -errno;

--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -54,6 +54,7 @@
 #include "tapdisk-fdreceiver.h"
 
 #include "timeout-math.h"
+#include "util.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -1379,8 +1380,7 @@ tapdisk_nbdserver_listen_unix(td_nbdserver_t *server)
 		goto out;
 	}
 
-	strncpy(server->local.sun_path, server->sockpath, sizeof(server->local.sun_path));
-	server->local.sun_path[sizeof(server->local.sun_path) - 1] = '\0';
+	safe_strncpy(server->local.sun_path, server->sockpath, sizeof(server->local.sun_path));
 	err = unlink(server->local.sun_path);
 	if (err == -1 && errno != ENOENT) {
 		err = -errno;

--- a/drivers/tapdisk-stats.c
+++ b/drivers/tapdisk-stats.c
@@ -144,7 +144,7 @@ tapdisk_stats_vval(td_stats_t *st, const char *conv, va_list ap)
 		break;
 
 	default:
-		sprintf(fmt, "%%%s", conv);
+		snprintf(fmt, sizeof(fmt), "%%%s", conv);
 		__stats_vsprintf(st, fmt, ap);
 		break;
 	}

--- a/drivers/td-rated.c
+++ b/drivers/td-rated.c
@@ -407,7 +407,8 @@ rlb_sock_open(td_rlb_t *rlb)
 			err = -ENAMETOOLONG;
 			goto fail;
 		}
-		strcpy(rlb->addr.sun_path, rlb->name);
+		strncpy(rlb->addr.sun_path, rlb->name, sizeof(rlb->addr.sun_path));
+		rlb->addr.sun_path[sizeof(rlb->addr.sun_path) - 1] = '\0';
 	} else
 		snprintf(rlb->addr.sun_path, sizeof(rlb->addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, rlb->name);

--- a/drivers/td-rated.c
+++ b/drivers/td-rated.c
@@ -407,8 +407,7 @@ rlb_sock_open(td_rlb_t *rlb)
 			err = -ENAMETOOLONG;
 			goto fail;
 		}
-		strncpy(rlb->addr.sun_path, rlb->name, sizeof(rlb->addr.sun_path));
-		rlb->addr.sun_path[sizeof(rlb->addr.sun_path) - 1] = '\0';
+		safe_strncpy(rlb->addr.sun_path, rlb->name, sizeof(rlb->addr.sun_path));
 	} else
 		snprintf(rlb->addr.sun_path, sizeof(rlb->addr.sun_path),
 			 "%s/%s", TD_VALVE_SOCKDIR, rlb->name);

--- a/include/util.h
+++ b/include/util.h
@@ -31,6 +31,22 @@
 #ifndef __TAPDISK_UTIL_H__
 #define __TAPDISK_UTIL_H_
 
+#include <stddef.h>
+#include <string.h>
+
 #define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
+
+/*
+ * Strncpy variant that guarantees to terminate the string
+ */
+static inline char *
+safe_strncpy(char *dest, const char *src, size_t n)
+{
+	char *pdest;
+	pdest = strncpy(dest, src, n);
+	if (n > 0)
+		dest[n - 1] = '\0';
+	return pdest;
+}
 
 #endif /* __TAPDISK_UTIL_H__ */

--- a/lvm/Makefile.am
+++ b/lvm/Makefile.am
@@ -13,6 +13,7 @@ lvm_util_SOURCES = main.c
 lvm_util_LDADD = liblvmutil.la
 
 liblvmutil_la_CPPFLAGS  = -D_GNU_SOURCE
+liblvmutil_la_CPPFLAGS += -I$(top_srcdir)/include
 
 clean-local:
 	-rm -rf *.gc??

--- a/lvm/lvm-util.c
+++ b/lvm/lvm-util.c
@@ -67,7 +67,8 @@ lvm_copy_name(char *dst, const char *src, size_t size)
 	if (strnlen(src, size) == size)
 		return -ENAMETOOLONG;
 
-	strcpy(dst, src);
+	strncpy(dst, src, size);
+	dst[size - 1] = '\0';
 	return 0;
 }
 

--- a/lvm/lvm-util.c
+++ b/lvm/lvm-util.c
@@ -39,6 +39,7 @@
 #include <syslog.h>
 
 #include "lvm-util.h"
+#include "util.h"
 
 #define EPRINTF(_f, _a...)					\
 	do {							\
@@ -67,8 +68,7 @@ lvm_copy_name(char *dst, const char *src, size_t size)
 	if (strnlen(src, size) == size)
 		return -ENAMETOOLONG;
 
-	strncpy(dst, src, size);
-	dst[size - 1] = '\0';
+	safe_strncpy(dst, src, size);
 	return 0;
 }
 

--- a/vhd/lib/canonpath.c
+++ b/vhd/lib/canonpath.c
@@ -109,7 +109,7 @@ normalize_path(const char *path, size_t path_len)
  * Symlinks are also kept if a /dev/drbd/by-res/<UUID>/<VOLUME_ID> path is used.
  */
 char *
-canonpath(const char *path, char *resolved_path)
+canonpath(const char *path, char *resolved_path, size_t dest_size)
 {
 	static const char dev_path[] = "/dev/";
 	static const size_t dev_len = sizeof(dev_path) - 1;
@@ -140,7 +140,8 @@ canonpath(const char *path, char *resolved_path)
 	if (strncmp(canon, dev_mapper_path, dev_mapper_len) == 0 &&
 	    strchr(canon + dev_mapper_len, '/') == NULL &&
 	    access(canon, F_OK) == 0) {
-		strcpy(resolved_path, canon);
+		strncpy(resolved_path, canon, dest_size);
+		resolved_path[dest_size - 1] = '\0';
 		goto end;
 	}
 
@@ -152,7 +153,8 @@ canonpath(const char *path, char *resolved_path)
 	 */
 	if (strncmp(canon, dev_path, dev_len) == 0 && (p = strchr(canon + dev_len, '/')) != NULL) {
 		if (strchr(p+1, '/') == NULL) {
-			strcpy(resolved_path, dev_mapper_path);
+			strncpy(resolved_path, dev_mapper_path, dest_size);
+			resolved_path[dest_size - 1] = '\0';
 			dst = strchr(resolved_path, 0);
 			for (p = canon + dev_len; *p; ++p) {
 				if (dst - resolved_path >= PATH_MAX - 2)
@@ -188,7 +190,8 @@ canonpath(const char *path, char *resolved_path)
 			if (p == resolved_path + dev_drbd_prefix_len || errno == ERANGE || *p != '\0')
 				goto end; /* Cannot parse correctly pattern. */
 
-			strcpy(resolved_path, canon);
+			strncpy(resolved_path, canon, dest_size);
+			resolved_path[dest_size - 1] = '\0';
 		} else
 			goto fallback;
 		if (access(resolved_path, F_OK) == 0)

--- a/vhd/lib/canonpath.c
+++ b/vhd/lib/canonpath.c
@@ -44,6 +44,7 @@
 #include <unistd.h>
 
 #include "canonpath.h"
+#include "util.h"
 
 char *
 normalize_path(const char *path, size_t path_len)
@@ -140,8 +141,7 @@ canonpath(const char *path, char *resolved_path, size_t dest_size)
 	if (strncmp(canon, dev_mapper_path, dev_mapper_len) == 0 &&
 	    strchr(canon + dev_mapper_len, '/') == NULL &&
 	    access(canon, F_OK) == 0) {
-		strncpy(resolved_path, canon, dest_size);
-		resolved_path[dest_size - 1] = '\0';
+		safe_strncpy(resolved_path, canon, dest_size);
 		goto end;
 	}
 
@@ -153,8 +153,7 @@ canonpath(const char *path, char *resolved_path, size_t dest_size)
 	 */
 	if (strncmp(canon, dev_path, dev_len) == 0 && (p = strchr(canon + dev_len, '/')) != NULL) {
 		if (strchr(p+1, '/') == NULL) {
-			strncpy(resolved_path, dev_mapper_path, dest_size);
-			resolved_path[dest_size - 1] = '\0';
+			safe_strncpy(resolved_path, dev_mapper_path, dest_size);
 			dst = strchr(resolved_path, 0);
 			for (p = canon + dev_len; *p; ++p) {
 				if (dst - resolved_path >= PATH_MAX - 2)
@@ -190,8 +189,7 @@ canonpath(const char *path, char *resolved_path, size_t dest_size)
 			if (p == resolved_path + dev_drbd_prefix_len || errno == ERANGE || *p != '\0')
 				goto end; /* Cannot parse correctly pattern. */
 
-			strncpy(resolved_path, canon, dest_size);
-			resolved_path[dest_size - 1] = '\0';
+			safe_strncpy(resolved_path, canon, dest_size);
 		} else
 			goto fallback;
 		if (access(resolved_path, F_OK) == 0)

--- a/vhd/lib/canonpath.h
+++ b/vhd/lib/canonpath.h
@@ -34,6 +34,6 @@
 /*
  * returns a canonical path from @path to @resolved_path
  */
-char *canonpath(const char *path, char *resolved_path);
+char *canonpath(const char *path, char *resolved_path, size_t dest_size);
 
 #endif

--- a/vhd/lib/libvhd-index.c
+++ b/vhd/lib/libvhd-index.c
@@ -248,7 +248,8 @@ vhdi_path_expand(const char *src, vhdi_path_t *dest, int *err)
 	char *path, *base, copy[VHD_MAX_NAME_LEN];
 	char *absolute_path, __absolute_path[PATH_MAX];
 
-	strcpy(copy, src);
+	strncpy(copy, src, sizeof(copy));
+	copy[sizeof(copy) - 1] = '\0';
 	base = dirname(copy);
 
 	*err = asprintf(&path, "%s/%s", base, dest->path);
@@ -838,7 +839,8 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.vhd_path, &err);
 	if (err)
 		goto out;
-	strcpy(bat->vhd_path, path);
+	strncpy(bat->vhd_path, path, sizeof(bat->vhd_path));
+	bat->vhd_path[sizeof(bat->vhd_path) - 1] = '\0';
 	free(path);
 
 	err = access(bat->vhd_path, F_OK);
@@ -850,7 +852,8 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.index_path, &err);
 	if (err)
 		goto out;
-	strcpy(bat->index_path, path);
+	strncpy(bat->index_path, path, sizeof(bat->index_path));
+	bat->index_path[sizeof(bat->index_path) - 1] = '\0';
 	free(path);
 
 	err = access(bat->index_path, F_OK);
@@ -862,7 +865,8 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.file_table_path, &err);
 	if (err)
 		goto out;
-	strcpy(bat->file_table_path, path);
+	strncpy(bat->file_table_path, path, sizeof(bat->file_table_path));
+	bat->file_table_path[sizeof(bat->file_table_path) - 1] = '\0';
 	free(path);
 
 	err = access(bat->file_table_path, F_OK);

--- a/vhd/lib/libvhd-index.c
+++ b/vhd/lib/libvhd-index.c
@@ -258,7 +258,7 @@ vhdi_path_expand(const char *src, vhdi_path_t *dest, int *err)
 		return NULL;
 	}
 
-	absolute_path = canonpath(path, __absolute_path);
+	absolute_path = canonpath(path, __absolute_path, sizeof(__absolute_path));
 	free(path);
 	if (absolute_path)
 		absolute_path = strdup(absolute_path);
@@ -692,7 +692,7 @@ vhdi_copy_path_to(vhdi_path_t *path, const char *src, const char *dest, size_t d
 	copy[sizeof(copy) - 1] = '\0';
 
 	file          = basename(copy);
-	absolute_path = canonpath(copy, __absolute_path);
+	absolute_path = canonpath(copy, __absolute_path, sizeof(__absolute_path));
 	relative_path = NULL;
 
 	if (!absolute_path) {
@@ -1080,7 +1080,7 @@ vhdi_file_table_next_fid(const char *name,
 	if (err)
 		return err;
 
-	path = canonpath(file, __path);
+	path = canonpath(file, __path, sizeof(__path));
 	if (!path) {
 		err = -errno;
 		goto out;

--- a/vhd/lib/libvhd-index.c
+++ b/vhd/lib/libvhd-index.c
@@ -47,6 +47,7 @@
 #include "libvhd-index.h"
 #include "relative-path.h"
 #include "canonpath.h"
+#include "util.h"
 
 typedef struct vhdi_path                    vhdi_path_t;
 typedef struct vhdi_header                  vhdi_header_t;
@@ -248,8 +249,7 @@ vhdi_path_expand(const char *src, vhdi_path_t *dest, int *err)
 	char *path, *base, copy[VHD_MAX_NAME_LEN];
 	char *absolute_path, __absolute_path[PATH_MAX];
 
-	strncpy(copy, src, sizeof(copy));
-	copy[sizeof(copy) - 1] = '\0';
+	safe_strncpy(copy, src, sizeof(copy));
 	base = dirname(copy);
 
 	*err = asprintf(&path, "%s/%s", base, dest->path);
@@ -688,8 +688,7 @@ vhdi_copy_path_to(vhdi_path_t *path, const char *src, const char *dest, size_t d
 	char *file, *relative_path, copy[VHD_MAX_NAME_LEN];
 	char *absolute_path, __absolute_path[PATH_MAX];
 
-	strncpy(copy, dest, sizeof(copy));
-	copy[sizeof(copy) - 1] = '\0';
+	safe_strncpy(copy, dest, sizeof(copy));
 
 	file          = basename(copy);
 	absolute_path = canonpath(copy, __absolute_path, sizeof(__absolute_path));
@@ -717,8 +716,7 @@ vhdi_copy_path_to(vhdi_path_t *path, const char *src, const char *dest, size_t d
 		goto out;
 	}
 
-	strncpy(path->path, relative_path, dest_size);
-	path->path[dest_size - 1] = '\0';
+	safe_strncpy(path->path, relative_path, dest_size);
 	path->bytes = len + 1;
 
 	err = 0;
@@ -841,8 +839,7 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.vhd_path, &err);
 	if (err)
 		goto out;
-	strncpy(bat->vhd_path, path, sizeof(bat->vhd_path));
-	bat->vhd_path[sizeof(bat->vhd_path) - 1] = '\0';
+	safe_strncpy(bat->vhd_path, path, sizeof(bat->vhd_path));
 	free(path);
 
 	err = access(bat->vhd_path, F_OK);
@@ -854,8 +851,7 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.index_path, &err);
 	if (err)
 		goto out;
-	strncpy(bat->index_path, path, sizeof(bat->index_path));
-	bat->index_path[sizeof(bat->index_path) - 1] = '\0';
+	safe_strncpy(bat->index_path, path, sizeof(bat->index_path));
 	free(path);
 
 	err = access(bat->index_path, F_OK);
@@ -867,8 +863,7 @@ vhdi_bat_load(const char *name, vhdi_bat_t *bat)
 	path = vhdi_path_expand(name, &header.file_table_path, &err);
 	if (err)
 		goto out;
-	strncpy(bat->file_table_path, path, sizeof(bat->file_table_path));
-	bat->file_table_path[sizeof(bat->file_table_path) - 1] = '\0';
+	safe_strncpy(bat->file_table_path, path, sizeof(bat->file_table_path));
 	free(path);
 
 	err = access(bat->file_table_path, F_OK);

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -57,6 +57,7 @@
 #include "relative-path.h"
 #include "canonpath.h"
 #include "compiler.h"
+#include "util.h"
 
 /* VHD uses an epoch of 12:00AM, Jan 1, 2000. This is the Unix timestamp for 
  * the start of the VHD epoch. */
@@ -2876,7 +2877,7 @@ vhd_initialize_footer(vhd_context_t *ctx, int type, uint64_t size)
 	ctx->footer.type         = type;
 	ctx->footer.saved        = 0;
 	ctx->footer.data_offset  = 0xFFFFFFFFFFFFFFFFULL;
-	strncpy(ctx->footer.crtr_app, "tap", sizeof(ctx->footer.crtr_app));
+	safe_strncpy(ctx->footer.crtr_app, "tap", sizeof(ctx->footer.crtr_app));
 	uuid_generate(ctx->footer.uuid);
 }
 

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -1543,7 +1543,7 @@ vhd_macx_encode_location(char *name, char **out, int *outlen)
 		goto out;
 	}
 
-	sprintf(uri, "file://%s", name);
+	snprintf(uri, ibl+1, "file://%s", name);
 
 	if (iconv(cd, &urip, &ibl, &uri_utf8p, &obl) == (size_t)-1 ||
 	    ibl || obl) {
@@ -2876,7 +2876,7 @@ vhd_initialize_footer(vhd_context_t *ctx, int type, uint64_t size)
 	ctx->footer.type         = type;
 	ctx->footer.saved        = 0;
 	ctx->footer.data_offset  = 0xFFFFFFFFFFFFFFFFULL;
-	strcpy(ctx->footer.crtr_app, "tap");
+	strncpy(ctx->footer.crtr_app, "tap", sizeof(ctx->footer.crtr_app));
 	uuid_generate(ctx->footer.uuid);
 }
 

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -1483,7 +1483,7 @@ vhd_find_parent(vhd_context_t *ctx, const char *parent, char **_location)
 	}
 
 	/* check parent path relative to child's directory */
-	cpath = canonpath(ctx->file, __cpath);
+	cpath = canonpath(ctx->file, __cpath, sizeof(__cpath));
 	if (!cpath) {
 		err = -errno;
 		goto out;
@@ -1497,7 +1497,7 @@ vhd_find_parent(vhd_context_t *ctx, const char *parent, char **_location)
 	}
 
 	if (!access(location, R_OK)) {
-		path = canonpath(location, __location);
+		path = canonpath(location, __location, sizeof(__location));
 		if (path) {
 			*_location = strdup(path);
 			if (*_location)
@@ -1918,7 +1918,7 @@ vhd_parent_locator_write_at(vhd_context_t *ctx,
 		return -EINVAL;
 	}
 
-	absolute_path = canonpath(parent, __parent);
+	absolute_path = canonpath(parent, __parent, sizeof(__parent));
 	if (!absolute_path) {
 		err = -errno;
 		goto out;
@@ -3072,7 +3072,7 @@ vhd_change_parent(vhd_context_t *child, char *parent_path, int raw)
 		return -EINVAL;
 	}
 
-	ppath = canonpath(parent_path, __parent_path);
+	ppath = canonpath(parent_path, __parent_path, sizeof(__parent_path));
 	if (!ppath) {
 		VHDLOG("error resolving parent path %s for %s: %d\n",
 		       parent_path, child->file, errno);

--- a/vhd/lib/relative-path.c
+++ b/vhd/lib/relative-path.c
@@ -240,14 +240,14 @@ relative_path_to(char *from, char *to, int *err)
 		return NULL;
 	}
 
-	to_absolute = canonpath(to, __to_absolute);
+	to_absolute = canonpath(to, __to_absolute, sizeof(__to_absolute));
 	if (!to_absolute) {
 		EPRINTF("failed to get absolute path of %s\n", to);
 		*err = -errno;
 		goto out;
 	}
 
-	from_absolute = canonpath(from, __from_absolute);
+	from_absolute = canonpath(from, __from_absolute, sizeof(__from_absolute));
 	if (!from_absolute) {
 		EPRINTF("failed to get absolute path of %s\n", from);
 		*err = -errno;

--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -257,13 +257,13 @@ vhd_util_pathcmp(const char *a, const char *b, int *cmp)
 	char *apath = NULL, __apath[PATH_MAX];
 	char *bpath = NULL, __bpath[PATH_MAX];
 
-	apath = canonpath(a, __apath);
+	apath = canonpath(a, __apath, sizeof(__apath));
 	if (!apath) {
 		err = -errno;
 		goto out;
 	}
 
-	bpath = canonpath(b, __bpath);
+	bpath = canonpath(b, __bpath, sizeof(__bpath));
 	if (!bpath) {
 		err = -errno;
 		goto out;

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -479,7 +479,7 @@ copy_name(char *dst, const char *src)
  * /dev/<vol-group>/<lv-name> becomes /dev/mapper/<vol--group>-<lv--name>
  */
 static int
-vhd_util_scan_extract_volume_name(char *dst, const char *src)
+vhd_util_scan_extract_volume_name(char *dst, const char *src, size_t size)
 {
 	char copy[VHD_MAX_NAME_LEN], *name, *s, *c;
 
@@ -504,11 +504,13 @@ vhd_util_scan_extract_volume_name(char *dst, const char *src)
 	c = strrchr(copy, '/');
 	if (c == name) {
 		/* unrecognized format */
-		strcpy(dst, src);
+		strncpy(dst, src, size);
+		dst[size - 1] = '\0';
 		return -EINVAL;
 	}
 
-	strcpy(dst, ++c);
+	strncpy(dst, ++c, size);
+	dst[size - 1] = '\0';
 	return 0;
 }
 
@@ -537,7 +539,7 @@ vhd_util_scan_get_volume_parent(vhd_context_t *vhd, struct vhd_image *image)
 		return err;
 
 found:
-	err = vhd_util_scan_extract_volume_name(name, image->parent);
+	err = vhd_util_scan_extract_volume_name(name, image->parent, sizeof(name));
 	if (!err)
 		return copy_name(image->parent, name);
 

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -788,7 +788,7 @@ vhd_util_scan_open(vhd_context_t *vhd, struct vhd_image *image)
 	else {
 		char __image_name[PATH_MAX];
 
-		image->name = canonpath(target->name, __image_name);
+		image->name = canonpath(target->name, __image_name, sizeof(__image_name));
 		if (image->name)
 			image->name = strdup(__image_name);
 		if (!image->name) {

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -50,6 +50,7 @@
 #include "libvhd.h"
 #include "lvm-util.h"
 #include "canonpath.h"
+#include "util.h"
 
 #define VHD_SCAN_FAST        0x01
 #define VHD_SCAN_PRETTY      0x02
@@ -504,13 +505,11 @@ vhd_util_scan_extract_volume_name(char *dst, const char *src, size_t size)
 	c = strrchr(copy, '/');
 	if (c == name) {
 		/* unrecognized format */
-		strncpy(dst, src, size);
-		dst[size - 1] = '\0';
+		safe_strncpy(dst, src, size);
 		return -EINVAL;
 	}
 
-	strncpy(dst, ++c, size);
-	dst[size - 1] = '\0';
+	safe_strncpy(dst, ++c, size);
 	return 0;
 }
 

--- a/vhd/lib/vhd-util-snapshot.c
+++ b/vhd/lib/vhd-util-snapshot.c
@@ -174,7 +174,7 @@ vhd_util_snapshot(int argc, char **argv)
 		goto usage;
 	}
 
-	ppath = canonpath(pname, __ppath);
+	ppath = canonpath(pname, __ppath, sizeof(__ppath));
 	if (!ppath)
 		return -errno;
 

--- a/vhd/vhd-index.c
+++ b/vhd/vhd-index.c
@@ -413,9 +413,12 @@ vhd_index_add_bat(vhdi_name_t *name,
 	bat.vhd_blocks     = vhd_blocks;
 	bat.vhd_block_size = vhd_block_size;
 
-	strcpy(bat.vhd_path, name->vhd);
-	strcpy(bat.index_path, name->index);
-	strcpy(bat.file_table_path, name->files);
+	strncpy(bat.vhd_path, name->vhd, sizeof(bat.vhd_path));
+	bat.vhd_path[sizeof(bat.vhd_path) - 1] = '\0';
+	strncpy(bat.index_path, name->index, sizeof(bat.index_path));
+	bat.index_path[sizeof(bat.index_path) - 1] = '\0';
+	strncpy(bat.file_table_path, name->files, sizeof(bat.file_table_path));
+	bat.file_table_path[sizeof(bat.file_table_path) - 1] = '\0';
 
 	err = vhdi_open(&vhdi, name->index, O_RDWR);
 	if (err)

--- a/vhd/vhd-index.c
+++ b/vhd/vhd-index.c
@@ -42,6 +42,7 @@
 
 #include "libvhd.h"
 #include "libvhd-index.h"
+#include "util.h"
 
 static void
 usage(void)
@@ -413,12 +414,9 @@ vhd_index_add_bat(vhdi_name_t *name,
 	bat.vhd_blocks     = vhd_blocks;
 	bat.vhd_block_size = vhd_block_size;
 
-	strncpy(bat.vhd_path, name->vhd, sizeof(bat.vhd_path));
-	bat.vhd_path[sizeof(bat.vhd_path) - 1] = '\0';
-	strncpy(bat.index_path, name->index, sizeof(bat.index_path));
-	bat.index_path[sizeof(bat.index_path) - 1] = '\0';
-	strncpy(bat.file_table_path, name->files, sizeof(bat.file_table_path));
-	bat.file_table_path[sizeof(bat.file_table_path) - 1] = '\0';
+	safe_strncpy(bat.vhd_path, name->vhd, sizeof(bat.vhd_path));
+	safe_strncpy(bat.index_path, name->index, sizeof(bat.index_path));
+	safe_strncpy(bat.file_table_path, name->files, sizeof(bat.file_table_path));
 
 	err = vhdi_open(&vhdi, name->index, O_RDWR);
 	if (err)


### PR DESCRIPTION
Coverity 2021.12.1 adds complaints about strcpy and sprintf, so fix them.