### PR TITLE
CA-365301 coverity: extend before left-shift

### DIFF
--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -1596,7 +1596,7 @@ schedule_redundant_bm_write(struct vhd_state *s, uint32_t blk)
 	offset = bat_entry(s, blk);
 	ASSERT(offset != DD_BLK_UNUSED);
 	offset <<= VHD_SECTOR_SHIFT;
-	offset -= s->padbm_size - (s->bm_secs << VHD_SECTOR_SHIFT);
+	offset -= s->padbm_size - ((uint64_t)s->bm_secs << VHD_SECTOR_SHIFT);
 
 	req->op        = VHD_OP_REDUNDANT_BM_WRITE;
 	req->treq.sec  = (td_sector_t)blk * s->spb;


### PR DESCRIPTION
Coverity worries that bits will be lost before the uint32_t is extended to the uint64_t context. This will not happen, but keep Coverity happy.

Signed-off-by: Tim Smith <tim.smith@citrix.com>