### PR TITLE
Relax xen_mb() from mfence to a locked instruction

### DIFF
--- a/include/blktap-xenif.h
+++ b/include/blktap-xenif.h
@@ -14,7 +14,11 @@
 
 /* Get the correct defines for memory barriers - do not fall
  * back to those provided by the kernel */
-#define xen_mb()  asm volatile ("mfence" ::: "memory")
+#ifdef __i386__
+#define xen_mb()  asm volatile ( "lock addl $0, -4(%%esp)" ::: "memory" )
+#else
+#define xen_mb()  asm volatile ( "lock addl $0, -32(%%rsp)" ::: "memory" )
+#endif
 #define xen_rmb() asm volatile ("" ::: "memory")
 #define xen_wmb() asm volatile ("" ::: "memory")
 


### PR DESCRIPTION
mfence is overly heavyweight.  See:

  https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=de16a8fa0db7f1879442cf9cfe865eb2e9d98e6d

for full details.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>