### PR TITLE
Make CBT Mocka tests work properly with devtoolset-11

### DIFF
--- a/mockatests/cbt/Makefile.am
+++ b/mockatests/cbt/Makefile.am
@@ -15,7 +15,7 @@ test_cbt_util_SOURCES = test-cbt-util.c test-cbt-util-commands.c test-cbt-util-s
 test_cbt_util_LDFLAGS = $(top_srcdir)/cbt/libcbtutil.la -lcmocka -luuid
 test_cbt_util_LDFLAGS += ../wrappers/libwrappers.la
 test_cbt_util_LDFLAGS += -Wl,--wrap=fopen,--wrap=fclose
-test_cbt_util_LDFLAGS += -Wl,--wrap=malloc,--wrap=free
+test_cbt_util_LDFLAGS += -Wl,--wrap=malloc,--wrap=free,--wrap=calloc
 # Need to wrap both of these as rpmbuild/mock set -D_FORTIFY_SOURCE=2
 test_cbt_util_LDFLAGS += -Wl,--wrap=printf,--wrap=__printf_chk
 # GCC will "optimise" printf calls - http://www.ciselant.de/projects/gcc_printf/gcc_printf.html

--- a/mockatests/wrappers/Makefile.am
+++ b/mockatests/wrappers/Makefile.am
@@ -1,8 +1,8 @@
 CFLAGS:=$(filter-out -fsanitize=leak,$(LDFLAGS))
 LDFLAGS:=$(filter-out -static-liblsan,$(LDFLAGS))
 
-AM_CFLAGS  = -Wall
-AM_CFLAGS += -Werror
+AM_CFLAGS = -Wall -g -Og
+AM_CFLAGS += -Werror -fno-inline
 
 AM_CPPFLAGS = -I../include
 

--- a/mockatests/wrappers/wrappers.c
+++ b/mockatests/wrappers/wrappers.c
@@ -45,16 +45,38 @@ static int mock_fwrite = 0;
 static int mock_vprintf = 0;
 static int mock_fseek = 0;
 
+bool should_malloc_succeed()
+{
+	return (bool) mock();
+}
+
 void *
 __wrap_malloc(size_t size)
 {
 	bool succeed = true;
 	if (mock_malloc) {
-		succeed = (bool) mock();
+		succeed = should_malloc_succeed();
 	}
 	if (succeed) {
 		void * result = test_malloc(size);
 		/*fprintf(stderr, "Allocated block of %zu bytes at %p\n", size, result);*/
+		return result;
+	}
+	return NULL;
+}
+
+
+void *
+__wrap_calloc(size_t nmemb, size_t size)
+{
+	bool succeed = true;
+	fprintf(stderr, "In calloc\n");
+	if (mock_malloc) {
+		succeed = should_malloc_succeed();
+	}
+	if (succeed) {
+		void * result = test_calloc(nmemb, size);
+		/*fprintf(stderr, "Calloc: Allocated block of %zu bytes at %p\n", size, result);*/
 		return result;
 	}
 	return NULL;
@@ -240,7 +262,7 @@ void fail_fseek(int Errno)
 void malloc_succeeds(bool succeed)
 {
 	mock_malloc = true;
-	will_return(__wrap_malloc, succeed);
+	will_return(should_malloc_succeed, succeed);
 }
 
 void disable_malloc_mock()


### PR DESCRIPTION
The devtoolset-11 compiler, when run with -O2 on the product code replaced a `malloc` + `memset` with a call to `calloc`, which then reported memory corruption errors when trying to use the `free` function from the mocka allocator library.