### PR TITLE
Silence GCC stringop-truncation warnings

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -43,7 +43,7 @@ static inline char *
 safe_strncpy(char *dest, const char *src, size_t n)
 {
 	char *pdest;
-	pdest = strncpy(dest, src, n);
+	pdest = strncpy(dest, src, n - 1);
 	if (n > 0)
 		dest[n - 1] = '\0';
 	return pdest;


### PR DESCRIPTION
The stringop-truncation warning will fire when there is an attempt to strncpy N characters into a destination string of length N, including the null character. The safe_strncpy() function does this for us by copying N characters and truncating at length N-1, but the previous strncpy() call is technically "incorrect" as GCC sees it. Reduce the sz by one to resolve these warnings. This behavior should be functionally equivalent to the original.