### PR TITLE
CP-37221: Optimise data management in vhd-util coalesce

### DIFF
--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -351,6 +351,7 @@ int vhd_read_header_at(vhd_context_t *, vhd_header_t *, off64_t);
 int vhd_read_bat(vhd_context_t *, vhd_bat_t *);
 int vhd_read_batmap(vhd_context_t *, vhd_batmap_t *);
 int vhd_read_bitmap(vhd_context_t *, uint32_t block, char **bufp);
+int vhd_read_at(vhd_context_t *ctx, uint64_t block, uint32_t from, size_t size, char *buf);
 int vhd_read_block(vhd_context_t *, uint32_t block, char **bufp);
 
 int vhd_write_footer(vhd_context_t *, vhd_footer_t *);

--- a/vhd/lib/vhd-util-coalesce.c
+++ b/vhd/lib/vhd-util-coalesce.c
@@ -73,7 +73,7 @@ vhd_util_coalesce_block(vhd_context_t *vhd, vhd_context_t *parent,
 			int parent_fd, uint64_t block)
 {
 	int i, err;
-	void *buf;
+	char *buf;
 	char *map;
 	uint64_t sec, secs;
 
@@ -84,11 +84,7 @@ vhd_util_coalesce_block(vhd_context_t *vhd, vhd_context_t *parent,
 	if (vhd->bat.bat[block] == DD_BLK_UNUSED)
 		return 0;
 
-	err = posix_memalign(&buf, 4096, vhd->header.block_size);
-	if (err)
-		return -err;
-
-	err = vhd_io_read(vhd, buf, sec, vhd->spb);
+	err = vhd_read_block(vhd, block, &buf);
 	if (err)
 		goto done;
 


### PR DESCRIPTION
Reduce the amount of data read during coalesce. Especially, do not read up the chain of parents when all that is required is the allocation block from the current VHD.