### PR TITLE
tap-clt: Improve list output filtering

### DIFF
--- a/control/tap-ctl.c
+++ b/control/tap-ctl.c
@@ -162,11 +162,21 @@ tap_cli_list(int argc, char **argv)
 		if (pid >= 0 && entry->pid != pid)
 			continue;
 
-		if (type && entry->type && strcmp(entry->type, type))
-			continue;
+		if (type) {
+			if (!entry->type)
+				continue;
 
-		if (file && entry->path && strcmp(entry->path, file))
-			continue;
+			if (strcmp(entry->type, type))
+				continue;
+		}
+
+		if (file) {
+			if (!entry->path)
+				continue;
+
+			if (strcmp(entry->path, file))
+				continue;
+		}
 
 		if (tty)
 			tap_cli_list_row(entry);


### PR DESCRIPTION
tap-ctl list is returning the allocated but unattached tapdevs when used with -t and -f.  We want to skip those since they don't match.

Full output:
$ tap-ctl list
  334529    1    0        vhd /home/user/test.vhd
  334534    2    0        aio /home/user/test.aio
       -    0    -          - -

Filtered before this change:
$ tap-ctl list -t vhd -f /home/user/test.vhd
  334529    1    0        vhd /home/user/test.vhd
       -    0    -          - -

Filtered after this change:
$ tap-ctl list -t vhd -f /home/user/test.vhd
  334529    1    0        vhd /home/user/test.vhd