### PR TITLE
Add an option to never resolve parent path when vhd-util query is called

### DIFF
--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -341,6 +341,7 @@ int vhd_initialize_header_parent_name(vhd_context_t *, const char *);
 int vhd_write_parent_locators(vhd_context_t *, const char *);
 int vhd_parent_locator_count(vhd_context_t *);
 int vhd_parent_locator_get(vhd_context_t *, char **);
+int vhd_parent_locator_unresolved_get(vhd_context_t *, char **);
 int vhd_custom_parent_set(vhd_context_t *vhd, const char *parent);
 
 int vhd_parent_locator_read(vhd_context_t *, vhd_parent_locator_t *, char **);

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -1782,8 +1782,8 @@ out:
 	return err;
 }
 
-int
-vhd_parent_locator_get(vhd_context_t *ctx, char **parent)
+static int
+vhd_parent_locator_get_impl(vhd_context_t *ctx, char **parent, bool resolve_parent)
 {
 	int i, n, err;
 	char *name, *location;
@@ -1807,6 +1807,11 @@ vhd_parent_locator_get(vhd_context_t *ctx, char **parent)
 		if (_err)
 			continue;
 
+		if (!resolve_parent) {
+			*parent = name;
+			return 0;
+		}
+
 		err = vhd_find_parent(ctx, name, &location);
 		if (err)
 			VHDLOG("%s: couldn't find parent %s (%d)\n",
@@ -1820,6 +1825,18 @@ vhd_parent_locator_get(vhd_context_t *ctx, char **parent)
 	}
 
 	return err;
+}
+
+int
+vhd_parent_locator_get(vhd_context_t *ctx, char **parent)
+{
+	return vhd_parent_locator_get_impl(ctx, parent, true);
+}
+
+int
+vhd_parent_locator_unresolved_get(vhd_context_t *ctx, char **parent)
+{
+	return vhd_parent_locator_get_impl(ctx, parent, false);
 }
 
 /**

--- a/vhd/lib/vhd-util-query.c
+++ b/vhd/lib/vhd-util-query.c
@@ -46,25 +46,26 @@ vhd_util_query(int argc, char **argv)
 	char *name;
 	vhd_context_t vhd;
 	off64_t currsize;
-	int ret, err, c, size, physize, parent, fields, depth, fastresize, marker, allocated;
+	int ret, err, c, size, physize, parent, fields, depth, fastresize, marker, allocated, resolve_parent;
 
-	name       = NULL;
-	size       = 0;
-	physize    = 0;
-	parent     = 0;
-	fields     = 0;
-	depth      = 0;
-	fastresize = 0;
-	marker     = 0;
-	allocated  = 0;
-
+	name           = NULL;
+	size           = 0;
+	physize        = 0;
+	parent         = 0;
+	fields         = 0;
+	depth          = 0;
+	fastresize     = 0;
+	marker         = 0;
+	allocated      = 0;
+	resolve_parent = 1;
+	
 	if (!argc || !argv) {
 		err = -EINVAL;
 		goto usage;
 	}
 
 	optind = 0;
-	while ((c = getopt(argc, argv, "n:vspfdSmah")) != -1) {
+	while ((c = getopt(argc, argv, "n:vspfdSmauh")) != -1) {
 		switch (c) {
 		case 'n':
 			name = optarg;
@@ -92,6 +93,9 @@ vhd_util_query(int argc, char **argv)
 			break;
 		case 'a':
 			allocated = 1;
+			break;
+		case 'u':
+			resolve_parent = 0;
 			break;
 		case 'h':
 			err = 0;
@@ -132,7 +136,7 @@ vhd_util_query(int argc, char **argv)
 		else {
 			char *pname;
 
-			ret = vhd_parent_locator_get(&vhd, &pname);
+			ret = resolve_parent ? vhd_parent_locator_get(&vhd, &pname) : vhd_parent_locator_unresolved_get(&vhd, &pname);
 			if (ret)
 				printf("query failed\n");
 			else {
@@ -212,6 +216,8 @@ usage:
 	       "[-s print physical utilization (bytes)] [-p print parent] "
 	       "[-f print fields] [-m print marker] [-d print chain depth] "
 	       "[-S print max virtual size (MB) for fast resize] "
-	       "[-a print allocated block count] [-h help]\n");
+	       "[-a print allocated block count] "
+	       "[-u don't resolve parent path] "
+	       "[-h help]\n");
 	return err;
 }


### PR DESCRIPTION
Add the ability to vhd-util to find the parent of a VHD without locally resolving or calling stat on the locator path.
A cmdline option `-u` (unresolved) is now available to query the parent path without resolution.

Use cases:
- When a special SR driver is used where the parent is not always accessible on the master (DRBD case).
- A copy of a VHD on an external device without parent
- ...

Example:
```
vhd-util query -u -n /dev/drbd/by-res/xcp-volume-1d86819f-c844-4250-8f3a-df5de9227baa/0 -p
../xcp-volume-56c6ef19-3d87-4838-b5e6-9c534bc1a0cb/0
```
