### PR TITLE
Guard against NULL tiocb in lio event handler

### DIFF
--- a/drivers/libaio-backend.c
+++ b/drivers/libaio-backend.c
@@ -425,7 +425,8 @@ libaio_backend_lio_event(event_id_t id, char mode, void *private)
 	for (i = split, ep = lio->aio_events; i-- > 0; ep++) {
 		iocb  = ep->obj;
 		tiocb = iocb->data;
-		complete_tiocb(queue, tiocb, ep->res);
+		if (tiocb)
+			complete_tiocb(queue, tiocb, ep->res);
 	}
 
 	queue_deferred_tiocbs(queue);


### PR DESCRIPTION
We have seen coredumps of the form 
```
#0  iocb_nbytes (io=0x10) at io-optimize.h:75
#1  complete_tiocb (queue=0x8de390, res=512, tiocb=0x0) at libaio-backend.c:177
#2  libaio_backend_lio_event (id=<optimized out>, mode=<optimized out>, private=0x8de390) at libaio-backend.c:428
#3  0x0000000000427371 in scheduler_event_callback (mode=1 '\001', event=0x8e0800) at scheduler.c:239
#4  scheduler_run_events (s=s@entry=0x43fdf8 <server+24>) at scheduler.c:258
#5  0x0000000000427a15 in scheduler_wait_for_events (s=<optimized out>, s@entry=0x43fdf8 <server+24>) at scheduler.c:427
#6  0x0000000000411417 in tapdisk_server_iterate () at tapdisk-server.c:403
#7  0x00000000004119d5 in __tapdisk_server_run () at tapdisk-server.c:420
#8  tapdisk_server_run () at tapdisk-server.c:855
#9  0x0000000000403b27 in main (argc=<optimized out>, argv=<optimized out>) at tapdisk2.c:160
```
Where it can be seen that the tiocb passed into `complete_tiocb` is NULL. Guard against this situation, likely only occurring during teardown, by checking before calling.