### PR TITLE
CP-46763: When VBD queue is not ready call the driver completion

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1344,7 +1344,7 @@ tapdisk_vbd_forward_request(td_request_t treq)
 	if (tapdisk_vbd_queue_ready(vbd))
 		__tapdisk_vbd_reissue_td_request(vbd, image, treq);
 	else
-		__tapdisk_vbd_complete_td_request(vbd, vreq, treq, -EBUSY);
+		td_complete_request(treq, -EBUSY);
 }
 
 int


### PR DESCRIPTION
When the tapdisk-vbd layer receives a request to forward an IO request it checks if the VBD queue is ready. If it not ready, either being quiesced or less likely is already quiesced, it fails the request with EBUSY to allow the entire request to be retired later. When doing so it directly calls its own internal completion function and does not notify the forwarding driver of the status which might result in that driver still believing the request to be in progress when it is asked to close.