### PR TITLE
CP-46777: don't issue new requests if there are failed to retry

### DIFF
--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -1654,6 +1654,10 @@ tapdisk_vbd_issue_new_requests(td_vbd_t *vbd)
 	int err;
 	td_vbd_request_t *vreq, *tmp;
 
+	if (!list_empty(&vbd->failed_requests)) {
+		return -EBUSY;
+	}
+
 	tapdisk_vbd_for_each_request(vreq, tmp, &vbd->new_requests) {
 		err = tapdisk_vbd_issue_request(vbd, vreq);
 		/*


### PR DESCRIPTION
When there are requests queued in the failed_requests list to be retried don't issue any new ones.