### PR TITLE
Fix the order of linker options in CBT

### DIFF
--- a/cbt/Makefile.am
+++ b/cbt/Makefile.am
@@ -11,7 +11,7 @@ noinst_LTLIBRARIES = libcbtutil.la
 libcbtutil_la_SOURCES = cbt-util.c
 
 cbt_util_SOURCES  = main.c
-cbt_util_LDADD  = -lrt -luuid libcbtutil.la
+cbt_util_LDADD  = libcbtutil.la -lrt -luuid
 
 clean-local:
 	-rm -rf *.gc??


### PR DESCRIPTION
In recent toolchain versions having the -l options before the .la file results in the exported functions in the libraries not being seen by the linker if LTO is disabled.