### PR TITLE
libxl blktap support

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -259,6 +259,15 @@ tapback_backend_create_device(backend_t *backend,
         goto out;
     }
 
+    /* After tapback has written it's capabilities to XenStore, switch to
+     * InitWait. */
+    err = xenbus_switch_state(device, XenbusStateInitWait);
+    if (unlikely(err)) {
+        WARN(device, "failed to switch to XenbusStateInitWait: %s\n",
+             strerror(-err));
+        goto out;
+    }
+
 out:
     if (err) {
         WARN(NULL, "%s: error creating device: %s\n", name, strerror(-err));

--- a/tapback/frontend.c
+++ b/tapback/frontend.c
@@ -439,8 +439,10 @@ frontend_changed(vbd_t * const device, const XenbusState state)
 
     switch (state) {
         case XenbusStateInitialising:
-			if (device->hotplug_status_connected)
-				err = xenbus_switch_state(device, XenbusStateInitWait);
+            if (device->state == XenbusStateClosed) {
+                DBG(device, "prepare for reconnect\n");
+                err = xenbus_switch_state(device, XenbusStateInitWait);
+            }
             break;
         case XenbusStateInitialised:
     	case XenbusStateConnected:

--- a/tapback/frontend.c
+++ b/tapback/frontend.c
@@ -479,7 +479,7 @@ tapback_backend_handle_otherend_watch(backend_t *backend,
 {
     vbd_t *device = NULL;
     int err = 0, state = 0;
-    char *s = NULL, *end = NULL, *_path = NULL;
+    char *s = NULL, *end = NULL;
 
 	ASSERT(backend);
     ASSERT(path);
@@ -510,41 +510,19 @@ tapback_backend_handle_otherend_watch(backend_t *backend,
      */
 	s = tapback_xs_read(device->backend->xs, XBT_NULL, "%s",
 			device->frontend_state_path);
-    if (!s) {
-        err = errno;
-		/*
-         * If the front-end XenBus node is missing, the XenBus device has been
-         * removed: remove the XenBus back-end node.
-		 */
-		if (err == ENOENT) {
-            err = asprintf(&_path, "%s/%s/%d/%d", XENSTORE_BACKEND,
-                    device->backend->name, device->domid, device->devid);
-            if (err == -1) {
-                err = errno;
-                WARN(device, "failed to asprintf: %s\n", strerror(err));
-                goto out;
-            }
-            err = 0;
-            if (!xs_rm(device->backend->xs, XBT_NULL, _path)) {
-                if (errno != ENOENT) {
-                    err = errno;
-                    WARN(device, "failed to remove %s: %s\n", path,
-                            strerror(err));
-                }
-            }
-		}
-    } else {
+    if (s) {
         state = strtol(s, &end, 0);
         if (*end != 0 || end == s) {
             WARN(device, "invalid XenBus state '%s'\n", s);
             err = EINVAL;
         } else
             err = frontend_changed(device, state);
+    } else {
+        WARN(device, "frontend disappeared!");
+        err = ENOENT;
     }
 
-out:
     free(s);
-    free(_path);
     return err;
 }
 


### PR DESCRIPTION
These two patches are the minimal needed for integration with libxl.

The InitWait handling needs a little modification to set it earlier.  libxl needs to see InitWait to run hotplug scripts which will write hotplug-status = "connected".  Setting InitWait earlier won't allow transitioning to Connected any earlier, so I *think* it should be okay with XAPI.  Howver, it has *not* been tested under XAPI.

The deleting of the xenstore backend is no longer performed.  libxl expects to find the backend to run the hotplug scripts to perform cleanup.  Later on, libxl will delete the entire domain sub-tree, so xenstore will get cleaned up that way.  Again, untested under XAPI.  Maybe XAPI does similar sub-tree cleanup so this isn't necessary?

If this isn't acceptable as-is, would a command line option & global flag for a "libxl mode" be acceptable to change behavior?