### PR TITLE
CA-384162: Send completions for all partial responses

### DIFF
--- a/drivers/block-valve.c
+++ b/drivers/block-valve.c
@@ -469,8 +469,12 @@ __valve_complete_treq(td_request_t treq, int error)
 	valve->done += TREQ_SIZE(treq);
 	valve_set_done_pending(valve);
 
+	/* Respond to original callback */
+	treq.cb = req->treq.cb;
+	treq.cb_data = req->treq.cb_data;
+	td_complete_request(treq, error);
+
 	if (!req->secs) {
-		td_complete_request(req->treq, error);
 		valve_free_request(valve, req);
 	}
 }


### PR DESCRIPTION
After tapdisk-vbd forwards a td_request_t to the next driver layer that driver is at liberty to decompose the request into smaller sub-requests, e.g. to accomodate spanning a VHD allocation block boundary. If this occurs, the individual sub-requests will complete independently and call the request callback in the higher driver layer.

The callback handler in block-valve, `__valve_complete_treq` does not correctly handle the condition if an intermediate request completes with an error but the final request which decrements the outstanding sector count to 0 suceeds. This results in a completion being sent to the next layer up the stack reporting that the entire IO request is complete when actually it is not and thus at some point later the guest VM will detect corruption to its disk structure, filesystem etc.

Correct this behaviour by forwarding the completion event to the next layer up the stack.