### PR TITLE
Fix various memory management issues

### DIFF
--- a/control/tap-ctl-allocate.c
+++ b/control/tap-ctl-allocate.c
@@ -137,7 +137,7 @@ tap_ctl_check_environment(void)
 {
 	FILE *f;
 	int err, minor;
-	char name[256];
+	char name[257];
 
 	err = tap_ctl_prepare_directory(BLKTAP2_CONTROL_DIR);
 	if (err) {

--- a/control/tap-ctl-check.c
+++ b/control/tap-ctl-check.c
@@ -45,7 +45,7 @@ tap_ctl_check_blktap(const char **msg)
 {
 	FILE *f;
 	int err = 0, minor;
-	char name[32];
+	char name[33];
 
 	memset(name, 0, sizeof(name));
 

--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -339,10 +339,11 @@ vhd_initialize(struct vhd_state *s)
 static void
 vhd_free(struct vhd_state *s)
 {
+	free(s->padbm_buf);
+
 	if (_vhd_master != s || !_vhd_zeros)
 		return;
 
-	free(s->padbm_buf);
 	munmap(_vhd_zeros, _vhd_zsize);
 	_vhd_zsize  = 0;
 	_vhd_zeros  = NULL;

--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -744,13 +744,20 @@ __load_crypto(struct td_vbd_encryption *encryption)
 	return 0;
 }
 
+void vhd_atexit(void)
+{
+	if (crypto_interface) {
+		free(crypto_interface);
+		crypto_interface = NULL;
+	}
+}
+
 static void
 __vhd_free_crypto(vhd_context_t *vhd)
 {
 	if (crypto_interface) {
 		crypto_interface->vhd_close_crypto(vhd);
-		free(crypto_interface);
-		crypto_interface = NULL;
+		atexit(vhd_atexit);
 	}
 }
 

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -692,7 +692,7 @@ tapdisk_control_detach_vbd(struct tapdisk_ctl_conn *conn,
 
 	if (list_empty(&vbd->images)) {
 		tapdisk_server_remove_vbd(vbd);
-		free(vbd);
+		tapdisk_vbd_free(vbd);
 	}
 
 out:
@@ -973,7 +973,7 @@ tapdisk_control_close_image(struct tapdisk_ctl_conn *conn,
 
 	if (!vbd->tap) {
 		tapdisk_server_remove_vbd(vbd);
-		free(vbd);
+		tapdisk_vbd_free(vbd);
 	}
 
 out:

--- a/drivers/tapdisk-diff.c
+++ b/drivers/tapdisk-diff.c
@@ -609,8 +609,7 @@ tapdisk_stream_close_image(struct tapdisk_stream *s)
 		tapdisk_vbd_close_vdi(vbd);
 		tapdisk_server_remove_vbd(vbd);
 		free((void *)vbd->ring.vstart);
-		free(vbd->name);
-		free(vbd);
+		tapdisk_vbd_free(vbd);
 		s->vbd = NULL;
 	}
 }

--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -252,6 +252,8 @@ tapdisk_image_open_parent(td_image_t *image, struct td_vbd_encryption *encryptio
             ((id.flags & TD_OPEN_LOCAL_CACHE) == TD_OPEN_LOCAL_CACHE))
 		id.flags &= ~TD_OPEN_NO_O_DIRECT;
 	err = tapdisk_image_open(id.type, id.name, id.flags, encryption, &parent);
+	/* Name has been duped to driver_name */
+	free(id.name);
 	if (err)
 		return err;
 

--- a/drivers/tapdisk-stream.c
+++ b/drivers/tapdisk-stream.c
@@ -360,8 +360,7 @@ tapdisk_stream_close_image(td_stream_t *s)
 	if (vbd) {
 		tapdisk_vbd_close_vdi(vbd);
 		tapdisk_server_remove_vbd(vbd);
-		free(vbd->name);
-		free(vbd);
+		tapdisk_vbd_free(vbd);
 		s->vbd = NULL;
 	}
 }

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -765,10 +765,17 @@ tapdisk_vbd_shutdown(td_vbd_t *vbd)
 	tapdisk_vbd_close_vdi(vbd);
 	tapdisk_vbd_detach(vbd);
 	tapdisk_server_remove_vbd(vbd);
-	free(vbd->name);
-	free(vbd);
+	tapdisk_vbd_free(vbd);
 
 	return 0;
+}
+
+void
+tapdisk_vbd_free(td_vbd_t *vbd)
+{
+	free(vbd->name);
+	free(vbd->encryption.encryption_key);
+	free(vbd);
 }
 
 int

--- a/drivers/tapdisk-vbd.h
+++ b/drivers/tapdisk-vbd.h
@@ -224,6 +224,7 @@ void tapdisk_vbd_squash_pause_logging(bool squash);
 int tapdisk_vbd_resume(td_vbd_t *, const char *);
 void tapdisk_vbd_kick(td_vbd_t *);
 void tapdisk_vbd_check_state(td_vbd_t *);
+void tapdisk_vbd_free(td_vbd_t *);
 
 void tapdisk_vbd_complete_td_request(td_request_t, int);
 int add_extent(tapdisk_extents_t *, td_request_t *);

--- a/vhd/lib/vhd-util-read.c
+++ b/vhd/lib/vhd-util-read.c
@@ -216,6 +216,7 @@ vhd_print_parent(vhd_context_t *vhd, vhd_parent_locator_t *loc)
 	}
 
 	printf("       decoded name : %s\n", buf);
+	free(buf);
 }
 
 static void

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -1149,6 +1149,11 @@ vhd_util_scan_find_file_targets(int cnt, char **names,
 		total += globs;
 	}
 
+	if (total == 0) {
+                err = 0;
+		goto out;
+        }
+
 	targets = calloc(total, sizeof(struct target));
 	if (!targets) {
 		err = -ENOMEM;


### PR DESCRIPTION
As we do `fscanf(f, "%d %32s", &minor, name)` we need a 33 char buffer