### PR TITLE
Remove no longer required xen API overrides

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -1,7 +1,6 @@
 SUBDIRS = crypto
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += -DXC_WANT_COMPAT_EVTCHN_API -DXC_WANT_COMPAT_GNTTAB_API
 AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/drivers -fprofile-arcs -ftest-coverage)
 # TODO add -Wextra
 


### PR DESCRIPTION
Blktap has been updated to only use the stable, modern APIs and so no longer needs to request compat APIs.