### PR TITLE
CA-391882: fix nbd connection fd leak bug

### DIFF
--- a/drivers/tapdisk-nbdserver.c
+++ b/drivers/tapdisk-nbdserver.c
@@ -823,6 +823,8 @@ tapdisk_nbdserver_free_client(td_nbdserver_client_t *client)
 	if (likely(!tapdisk_nbdserver_reqs_pending(client))) {
 		list_del(&client->clientlist);
 		tapdisk_nbdserver_reqs_free(client);
+		if (client->client_fd > 0)
+			close(client->client_fd);
 		free(client);
 	} else
 		client->dead = true;
@@ -1107,7 +1109,6 @@ tapdisk_nbdserver_newclient_fd_old(td_nbdserver_t *server, int new_fd)
 	if (tapdisk_nbdserver_enable_client(client) < 0) {
 		ERR("Error enabling client");
 		tapdisk_nbdserver_free_client(client);
-		close(new_fd);
 	}
 }
 
@@ -1130,19 +1131,18 @@ tapdisk_nbdserver_newclient_fd_new_fixed(td_nbdserver_t *server, int new_fd)
 	}
 	INFO("Got an allocated client at %p", client);
 
+	client->client_fd = new_fd;
+
 	if(tapdisk_nbdserver_new_protocol_handshake(client, new_fd) != 0) {
 		ERR("Error handshaking new client connection");
 		tapdisk_nbdserver_free_client(client);
 		return;
 	}
 
-	client->client_fd = new_fd;
-
 	INFO("About to enable client on fd %d", client->client_fd);
 	if (tapdisk_nbdserver_enable_client(client) < 0) {
 		ERR("Error enabling client");
 		tapdisk_nbdserver_free_client(client);
-		close(new_fd);
 	}
 }
 
@@ -1262,12 +1262,8 @@ tapdisk_nbdserver_clientcb(event_id_t id, char mode, void *data)
 
 		break;
 	case TAPDISK_NBD_CMD_DISC:
-		INFO("Received close message. Sending reconnect "
-				"header");
+		INFO("Received close message. Free client");
 		tapdisk_nbdserver_free_client(client);
-		INFO("About to send initial connection message");
-		tapdisk_nbdserver_newclient_fd(server, fd);
-		INFO("Sent initial connection message");
 		return;
 	case TAPDISK_NBD_CMD_BLOCK_STATUS:
 	{


### PR DESCRIPTION
  When nbd server receives disconnect request from client, it frees
  client data structure but it does not close the connection, then
  it sends VDI size to client, the send most likely returns err as
  client fd has been closed. However, in some case like half close,
  send returns successfully, and then server will always keep this
  opened fd in memory and never close it, finally, the number of
  opened fd exceeds ulimit settings.