### PR TITLE
CA-392151 lcache.c uses wrong buffer size definition

### DIFF
--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -73,12 +73,17 @@ extern unsigned int PAGE_SIZE;
 extern unsigned int PAGE_MASK;
 extern unsigned int PAGE_SHIFT;
 
-#define MAX_SEGMENTS_PER_REQ         11
+// Removed definition of MAX_SEGMENTS_PER_REQ from here. Use BLKIF_MAX_SEGMENTS_PER_REQUEST
+// which must match the value in xen/io/blkif.h, trying to make it clear that these are
+// the same thing.
+#ifndef BLKIF_MAX_SEGMENTS_PER_REQUEST
+#define BLKIF_MAX_SEGMENTS_PER_REQUEST 11
+#endif
 #define MAX_REQUESTS                 32U
 #define SECTOR_SHIFT                 9
 #define DEFAULT_SECTOR_SIZE          512
 
-#define TAPDISK_DATA_REQUESTS       (MAX_REQUESTS * MAX_SEGMENTS_PER_REQ)
+#define TAPDISK_DATA_REQUESTS       (MAX_REQUESTS * BLKIF_MAX_SEGMENTS_PER_REQUEST)
 
 //#define BLK_NOT_ALLOCATED            (-99)
 #define TD_NO_PARENT                 1

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -121,7 +121,7 @@ td_xenblkif_bufcache_free(struct td_xenblkif * const blkif)
 
     while (blkif->n_reqs_bufcache_free > TD_REQS_BUFCACHE_MIN){
         munmap(blkif->reqs_bufcache[--blkif->n_reqs_bufcache_free],
-               (size_t)BLKIF_MMAX_SEGMENTS_PER_REQUEST << PAGE_SHIFT);
+               (size_t)BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST << PAGE_SHIFT);
     }
 }
 
@@ -138,7 +138,7 @@ td_xenblkif_bufcache_get(struct td_xenblkif * const blkif)
     ASSERT(blkif);
 
     if (!blkif->n_reqs_bufcache_free) {
-	    buf = mmap(NULL, (size_t)BLKIF_MMAX_SEGMENTS_PER_REQUEST << PAGE_SHIFT,
+	    buf = mmap(NULL, (size_t)TD_REQ_BUFFER_SIZE,
                    PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         if (unlikely(buf == MAP_FAILED))
             buf = NULL;
@@ -784,7 +784,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
      */
     if (unlikely((tapreq->msg.nr_segments == 0 &&
                 tapreq->msg.operation != BLKIF_OP_WRITE_BARRIER) ||
-            tapreq->msg.nr_segments > BLKIF_MMAX_SEGMENTS_PER_REQUEST)) {
+            tapreq->msg.nr_segments > BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST)) {
         RING_ERR(blkif, "req %lu: bad number of segments in request (%d)\n",
                 tapreq->msg.id, tapreq->msg.nr_segments);
         err = EINVAL;

--- a/drivers/td-req.h
+++ b/drivers/td-req.h
@@ -38,6 +38,8 @@
 #include <xen/gntdev.h>
 #include "td-blkif.h"
 
+#define TD_REQ_BUFFER_SIZE (BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST << PAGE_SHIFT)
+
 /**
  * Representation of the intermediate request used to retrieve a request from
  * the shared ring and handle it over to the main tapdisk request processing
@@ -78,9 +80,9 @@ struct td_xenblkif_req {
     /**
      * The scatter/gather list td_vbd_request_t.iov points to.
      */
-    struct td_iovec iov[BLKIF_MMAX_SEGMENTS_PER_REQUEST];
+    struct td_iovec iov[BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST];
 
-    grant_ref_t gref[BLKIF_MMAX_SEGMENTS_PER_REQUEST];
+    grant_ref_t gref[BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST];
     int prot;
 
 	struct gntdev_grant_copy_segment

--- a/include/blktaplib.h
+++ b/include/blktaplib.h
@@ -226,11 +226,11 @@ typedef struct msg_lock {
 
 /* Accessing attached data page mappings */
 #define MMAP_PAGES                                                    \
-    (MAX_PENDING_REQS * BLKIF_MMAX_SEGMENTS_PER_REQUEST)
+    (MAX_PENDING_REQS * BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST)
 #define MMAP_VADDR(_vstart,_req,_seg)                                 \
     ((_vstart) +                                                      \
-     ((_req) * BLKIF_MMAX_SEGMENTS_PER_REQUEST * getpagesize()) +      \
-     ((_seg) * getpagesize()))
+     ((_req) * BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST * PAGE_SIZE) +      \
+     ((_seg) * PAGE_SIZE))
 
 /* Defines that are only used by library clients */
 

--- a/include/xen_blkif.h
+++ b/include/xen_blkif.h
@@ -133,6 +133,6 @@ static inline void blkif_get_x86_64_req(blkif_request_t *dst, blkif_x86_64_reque
 #define MAX_RING_PAGE_ORDER 3
 #define MAX_RING_PAGES (1 << MAX_RING_PAGE_ORDER)
 
-#define BLKIF_MMAX_SEGMENTS_PER_REQUEST 32
+#define BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST 32
 
 #endif /* __XEN_BLKIF_H__ */


### PR DESCRIPTION
To compute its buffer size, block-lcache.c was using MAX_SEGMENTS_PER_REQ, which has the same value as
BLKIF_MAX_SEGMENTS_PER_REQ (11 at present).

However, td-req.c used BLKIF_MMAX_SEGMENTS_PER_REQ (Note the additional "M") which has a different value (32). Thus it is possible for a td-req entity passed to the "tapdisk_lcache" driver to be bigger than the driver can handle. But the driver doesn't check this and assumes it has enough space for the memcpy(), resulting in... trouble.

Correct the calculation in block-lcache.c to match the calculation in td-req.c by sharing a new TD_REQ_BUFFER_SIZE macro via td_req.h

To help prevent further confusion, remove the local definition of MAX_SEGMENTS_PER_REQ and use BLKIF_MAX_SEGMENTS_PER_REQ in place of it, so that things which are supposed to be the same at least have the same name. Rename BLKIF_MMAX_SEGMENTS_PER_REQ to
BLKIF_MAX_BUFFER_SEGMENTS_PER_REQUEST to make it more clear that this is supposed to be different.