### PR TITLE
CA-403297: when storing read-through do not mirror

### DIFF
--- a/drivers/block-lcache.c
+++ b/drivers/block-lcache.c
@@ -284,6 +284,7 @@ lcache_store_read(td_lcache_t *cache, td_lcache_req_t *req)
 	vreq->iovcnt = 1;
 	vreq->cb     = __lcache_write_cb;
 	vreq->token  = cache;
+	vreq->skip_mirror = true;
 
 	vbd = req->treq.vreq->vbd;
 

--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -177,6 +177,8 @@ struct td_vbd_request {
 	int                         num_retries;
 	struct timeval		    ts;
 	struct timeval              last_try;
+	/* When "reading-through" the local cache, don't write back to the source */
+	bool                        skip_mirror;
 
 	td_vbd_t                   *vbd;
 	struct list_head            next;


### PR DESCRIPTION
When the lcache driver has read from the remote storage and returned the data to the caller it then stores the data into the local vhdcache by forwarding a write to the vhdcache file. As the vhdcache file is opened in TD_VBD_SECONDARY_MIRROR mode this also results in the data being unnecessarily written back to the remote where it has just been read from.