### PR TITLE
CA-387574: Fix build time coverage gathering

### DIFF
--- a/cbt/Makefile.am
+++ b/cbt/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/cbt -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 

--- a/collect-test-results.sh
+++ b/collect-test-results.sh
@@ -11,16 +11,9 @@ fi
 
 mkdir -p $OUTPUT_DIR
 
-find . -name \*.gcda -exec rm {} \;
-
-lcov --capture --initial --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage_base.info
-
-(cd /tmp/coverage/blktap; tar cf - `find . -name \*.gcda`) | tar xf -
-
-lcov --capture --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage_test.info
-lcov --rc lcov_branch_coverage=1 --add-tracefile $OUTPUT_DIR/coverage_base.info --add-tracefile $OUTPUT_DIR/coverage_test.info --output-file $OUTPUT_DIR/coverage.info
+lcov --capture --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage.info
 genhtml $OUTPUT_DIR/coverage.info  --rc lcov_branch_coverage=1 --output-directory $OUTPUT_DIR/coverage-html
 tar cf $OUTPUT_DIR/test-results.tar `find mockatests -name \*.log`
 tar cf $OUTPUT_DIR/gcov-files.tar `find . -name \*.gcda -or -name \*.gcno`
 
-lcov -l $OUTPUT_DIR/coverage.info
+lcov --rc lcov_branch_coverage=1 -l $OUTPUT_DIR/coverage.info

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -1,7 +1,7 @@
 
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/control -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 AM_CFLAGS += -g
 
 AM_CPPFLAGS  = -D_GNU_SOURCE

--- a/cpumond/Makefile.am
+++ b/cpumond/Makefile.am
@@ -1,7 +1,7 @@
 
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/cpumond -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 AM_CPPFLAGS  = -D_GNU_SOURCE
 AM_CPPFLAGS += -I$(top_srcdir)/include

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = crypto
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/drivers -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 # TODO add -Wextra
 
 AM_CPPFLAGS  = -D_GNU_SOURCE

--- a/lvm/Makefile.am
+++ b/lvm/Makefile.am
@@ -1,7 +1,7 @@
 
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/lvm -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 sbin_PROGRAMS = lvm-util
 

--- a/mockatests/cbt/Makefile.am
+++ b/mockatests/cbt/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += -fprofile-dir=/tmp/coverage/blktap/mockatests/cbt -fprofile-arcs -ftest-coverage
+AM_CFLAGS += -fprofile-arcs -ftest-coverage
 AM_CFLAGS += -Og -fno-inline-functions -g
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/cbt -I../include

--- a/mockatests/control/Makefile.am
+++ b/mockatests/control/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += -fprofile-dir=/tmp/coverage/blktap/mockatests/control -fprofile-arcs -ftest-coverage
+AM_CFLAGS += -fprofile-arcs -ftest-coverage
 AM_CFLAGS += -Og -fno-inline -g
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/control -I../include

--- a/mockatests/drivers/Makefile.am
+++ b/mockatests/drivers/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += -fprofile-dir=/tmp/coverage/blktap/mockatests/drivers -fprofile-arcs -ftest-coverage
+AM_CFLAGS += -fprofile-arcs -ftest-coverage
 AM_CFLAGS += -Og -fno-inline-functions -g
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/drivers -I../include

--- a/mockatests/vhd/Makefile.am
+++ b/mockatests/vhd/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += -fprofile-dir=/tmp/coverage/blktap/mockatests/vhd -fprofile-arcs -ftest-coverage
+AM_CFLAGS += -fprofile-arcs -ftest-coverage
 AM_CFLAGS += -Og -fno-inline-functions -g
 AM_CFLAGS += -Doff64_t=__off64_t
 

--- a/tapback/Makefile.am
+++ b/tapback/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
 AM_CFLAGS += -Wextra
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/tapback -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 AM_CPPFLAGS  = -D_GNU_SOURCE # required by vasprintf
 AM_CPPFLAGS += -I$(top_srcdir)/include

--- a/vhd/Makefile.am
+++ b/vhd/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = lib
 
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/vhd -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 AM_CPPFLAGS  = -D_GNU_SOURCE
 AM_CPPFLAGS += -I$(top_srcdir)/include

--- a/vhd/lib/Makefile.am
+++ b/vhd/lib/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = . $(MAYBE_test)
 
 AM_CFLAGS  = -Wall
 AM_CFLAGS += -Werror
-AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/vhd/lib -fprofile-arcs -ftest-coverage)
+AM_CFLAGS += $(if $(GCOV),-fprofile-arcs -ftest-coverage)
 
 AM_CPPFLAGS  = -D_GNU_SOURCE
 AM_CPPFLAGS += -I$(top_srcdir)/include


### PR DESCRIPTION
Directing the profile-dir to an out of tree location results in gcc 12 creating paths with the separators of the absolute source path converted to # characters. When subsequently using gcov or lcov to analyse the coverage this produces errors and no coverage data is produced. As the collect-test-results.sh pulls these files back into the build tree and published them from there it isn't necessary to write them elsewhere and this avoids the decorated paths being created.