### PR TITLE
CA-387574: Get coverage for all files

### DIFF
--- a/collect-test-results.sh
+++ b/collect-test-results.sh
@@ -11,7 +11,9 @@ fi
 
 mkdir -p $OUTPUT_DIR
 
-lcov --capture --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage.info
+lcov --capture --initial --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage_base.info
+lcov --capture --directory . --rc lcov_branch_coverage=1 --no-external --output-file $OUTPUT_DIR/coverage_test.info
+lcov --rc lcov_branch_coverage=1 --add-tracefile $OUTPUT_DIR/coverage_base.info --add-tracefile $OUTPUT_DIR/coverage_test.info --output-file $OUTPUT_DIR/coverage.info
 genhtml $OUTPUT_DIR/coverage.info  --rc lcov_branch_coverage=1 --output-directory $OUTPUT_DIR/coverage-html
 tar cf $OUTPUT_DIR/test-results.tar `find mockatests -name \*.log`
 tar cf $OUTPUT_DIR/gcov-files.tar `find . -name \*.gcda -or -name \*.gcno`


### PR DESCRIPTION
The previous change 8c5bb7d, inadvertently omitted a number of 0% coverage files, presenting a misleading report of coverage. Rectify that by calling lcov with a --initial.