### PR TITLE
CP-308276: vhd_batmap_header_offset only returns 0 thus is void.

### DIFF
--- a/include/libvhd.h
+++ b/include/libvhd.h
@@ -311,7 +311,7 @@ int vhd_offset(vhd_context_t *, uint32_t, uint32_t *);
 
 int vhd_end_of_headers(vhd_context_t *ctx, off64_t *off);
 int vhd_end_of_data(vhd_context_t *ctx, off64_t *off);
-int vhd_batmap_header_offset(vhd_context_t *ctx, off64_t *off);
+off64_t vhd_batmap_header_offset(vhd_context_t *ctx);
 
 int vhd_get_header(vhd_context_t *);
 int vhd_get_footer(vhd_context_t *);

--- a/vhd/lib/libvhd-journal.c
+++ b/vhd/lib/libvhd-journal.c
@@ -586,9 +586,7 @@ vhd_journal_add_batmap(vhd_journal_t *j)
 
 	vhd  = &j->vhd;
 
-	err  = vhd_batmap_header_offset(vhd, &off);
-	if (err)
-		return err;
+	off = vhd_batmap_header_offset(vhd);
 
 	err  = vhd_read_batmap(vhd, &batmap);
 	if (err)

--- a/vhd/lib/libvhd.c
+++ b/vhd/lib/libvhd.c
@@ -566,20 +566,17 @@ vhd_validate_batmap(vhd_context_t *ctx, vhd_batmap_t *batmap)
 	return 0;
 }
 
-int
-vhd_batmap_header_offset(vhd_context_t *ctx, off64_t *_off)
+off64_t
+vhd_batmap_header_offset(vhd_context_t *ctx)
 {
 	off64_t off;
 	size_t  bat;
-
-	*_off = 0;
 
 	off  = ctx->header.table_offset;
 	bat  = ctx->header.max_bat_size * sizeof(uint32_t);
 	off += vhd_bytes_padded(bat);
 
-	*_off = off;
-	return 0;
+	return off;
 }
 
 int
@@ -771,9 +768,7 @@ vhd_end_of_headers(vhd_context_t *ctx, off64_t *end)
 			return err;
 
 		hdr_secs = secs_round_up_no_zero(sizeof(vhd_batmap_header_t));
-		err      = vhd_batmap_header_offset(ctx, &hdr_end);
-		if (err)
-			return err;
+		hdr_end = vhd_batmap_header_offset(ctx);
 
 		hdr_end += vhd_sectors_to_bytes(hdr_secs);
 		eom      = MAX(eom, hdr_end);
@@ -1274,9 +1269,7 @@ vhd_read_batmap_header(vhd_context_t *ctx, vhd_batmap_t *batmap)
 
 	buf = NULL;
 
-	err = vhd_batmap_header_offset(ctx, &off);
-	if (err)
-		goto fail;
+	off = vhd_batmap_header_offset(ctx);
 
 	err = vhd_seek(ctx, off, SEEK_SET);
 	if (err)
@@ -2280,9 +2273,7 @@ vhd_write_batmap_header(vhd_context_t *ctx, vhd_batmap_t *batmap)
 	off64_t off;
 	void *buf = NULL;
 
-	err = vhd_batmap_header_offset(ctx, &off);
-	if (err)
-		goto out;
+	off = vhd_batmap_header_offset(ctx);
 
 	size = vhd_bytes_padded(sizeof(*batmap));
 
@@ -2356,9 +2347,7 @@ vhd_write_batmap(vhd_context_t *ctx, vhd_batmap_t *batmap)
 	if (err)
 		goto out;
 
-	err  = vhd_batmap_header_offset(ctx, &off);
-	if (err)
-		goto out;
+	off = vhd_batmap_header_offset(ctx);
 
 	size = vhd_bytes_padded(sizeof(vhd_batmap_header_t));
 
@@ -3158,9 +3147,7 @@ vhd_create_batmap(vhd_context_t *ctx)
 	memset(header, 0, sizeof(vhd_batmap_header_t));
 	memcpy(header->cookie, VHD_BATMAP_COOKIE, sizeof(header->cookie));
 
-	err = vhd_batmap_header_offset(ctx, &off);
-	if (err)
-		return err;
+	off = vhd_batmap_header_offset(ctx);
 
 	header->batmap_offset  = off +
 		vhd_bytes_padded(sizeof(vhd_batmap_header_t));

--- a/vhd/lib/vhd-util-resize.c
+++ b/vhd/lib/vhd-util-resize.c
@@ -429,9 +429,7 @@ vhd_clear_bat_entries(vhd_journal_t *journal, uint32_t entries)
 	new_entries  = orig_entries - entries;
 
 	if (vhd_has_batmap(vhd)) {
-		err = vhd_batmap_header_offset(vhd, &orig_map_off);
-		if (err)
-			return err;
+		orig_map_off = vhd_batmap_header_offset(vhd);
 	}
 
 	/* update header */
@@ -462,9 +460,7 @@ vhd_clear_bat_entries(vhd_journal_t *journal, uint32_t entries)
 		return 0;
 
 	/* zero out old batmap header if new header has moved */
-	err = vhd_batmap_header_offset(vhd, &new_map_off);
-	if (err)
-		return err;
+	new_map_off = vhd_batmap_header_offset(vhd);
 
 	if (orig_map_off != new_map_off) {
 		size_t size;


### PR DESCRIPTION
It does set its `*off` parameter so convert this to return the offset instead of updating an input parameter and returning a useless error code. Remove the now dead call site error checking.