### PR TITLE
CP-52937 Update Tapdisk Tools to enable to use base64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,8 @@
 
 # FIXME run cppcheck
 
-SUBDIRS  = lvm
+SUBDIRS  = lib
+SUBDIRS += lvm
 SUBDIRS += vhd
 SUBDIRS += cpumond
 SUBDIRS += control

--- a/cbt/Makefile.am
+++ b/cbt/Makefile.am
@@ -9,7 +9,7 @@ sbin_PROGRAMS = cbt-util
 noinst_LTLIBRARIES = libcbtutil.la
 
 libcbtutil_la_SOURCES = cbt-util.c
-libcbtutil_la_LIBADD = -luuid
+libcbtutil_la_LIBADD = -luuid $(top_builddir)/lib/libblktaputil.la
 
 cbt_util_SOURCES  = main.c
 cbt_util_LDADD  = libcbtutil.la

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,7 @@ AC_DEFINE(_BLKTAP, 1,
 		  Indicates whether this is an internal or external compilation.)
 AC_CONFIG_FILES([
 Makefile
+lib/Makefile
 lvm/Makefile
 cpumond/Makefile
 cbt/Makefile

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS += -DTAPDISK_EXECDIR='"$(libexecdir)"'
 AM_CPPFLAGS += -DTAPDISK_BUILDDIR='"$(top_builddir)/drivers"'
 
 sbin_PROGRAMS = tap-ctl
-tap_ctl_LDADD = libblktapctl.la
+tap_ctl_SOURCES = tap-ctl.c
+tap_ctl_LDADD = libblktapctl.la $(top_builddir)/lib/libblktaputil.la
 
 lib_LTLIBRARIES = libblktapctl.la
 

--- a/include/util.h
+++ b/include/util.h
@@ -33,6 +33,7 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <stdint.h>
 
 #define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
 
@@ -48,5 +49,16 @@ safe_strncpy(char *dest, const char *src, size_t n)
 		dest[n - 1] = '\0';
 	return pdest;
 }
+
+/*
+ * Constants for cryptographic operations
+ */
+#define MAX_AES_XTS_PLAIN_KEYSIZE 1024
+
+/*
+ * Base64 encoding/decoding utilities using OpenSSL
+ */
+int base64_encode_data(const uint8_t *input, size_t input_len, char **output);
+int base64_decode_key(const char *input, uint8_t *output, size_t *output_len);
 
 #endif /* __TAPDISK_UTIL_H__ */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,0 +1,14 @@
+AM_CFLAGS  = -Wall
+AM_CFLAGS += -Werror
+AM_CFLAGS += $(if $(GCOV),-fprofile-dir=/tmp/coverage/blktap/lib -fprofile-arcs -ftest-coverage)
+
+AM_CPPFLAGS = -I$(top_srcdir)/include
+
+lib_LTLIBRARIES = libblktaputil.la
+
+libblktaputil_la_SOURCES = util.c
+libblktaputil_la_LDFLAGS = -version-info 1:0:0
+libblktaputil_la_LIBADD = -lssl -lcrypto
+
+clean-local:
+	-rm -rf *.gc??

--- a/lib/util.c
+++ b/lib/util.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its 
+ *     contributors may be used to endorse or promote products derived from 
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/buffer.h>
+
+#include "util.h"
+
+int 
+base64_encode_data(const uint8_t *input, size_t input_len, char **output)
+{
+	BIO *bio, *b64;
+	BUF_MEM *bufferPtr;
+	
+	if (!input || input_len == 0 || !output) {
+		return -1;
+	}
+	
+	*output = NULL;
+	
+	b64 = BIO_new(BIO_f_base64());
+	bio = BIO_new(BIO_s_mem());
+	if (!b64 || !bio) {
+		if (b64) BIO_free(b64);
+		if (bio) BIO_free(bio);
+		return -1;
+	}
+	
+	bio = BIO_push(b64, bio);
+	BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+	
+	if (BIO_write(bio, input, input_len) != (int)input_len) {
+		BIO_free_all(bio);
+		return -1;
+	}
+	
+	if (BIO_flush(bio) != 1) {
+		BIO_free_all(bio);
+		return -1;
+	}
+	
+	BIO_get_mem_ptr(bio, &bufferPtr);
+	*output = malloc(bufferPtr->length + 1);
+	if (!*output) {
+		BIO_free_all(bio);
+		return -1;
+	}
+	
+	memcpy(*output, bufferPtr->data, bufferPtr->length);
+	(*output)[bufferPtr->length] = '\0';
+	
+	BIO_free_all(bio);
+	return 0;
+}
+
+int 
+base64_decode_key(const char *input, uint8_t *output, size_t *output_len)
+{
+	BIO *bio, *b64;
+	int decoded_len;
+	
+	if (!input || !output || !output_len || strlen(input) == 0) {
+		return -1;
+	}
+	
+	*output_len = 0;
+	
+	b64 = BIO_new(BIO_f_base64());
+	bio = BIO_new_mem_buf((void*)input, strlen(input));
+	if (!b64 || !bio) {
+		if (b64) BIO_free(b64);
+		if (bio) BIO_free(bio);
+		return -1;
+	}
+	
+	bio = BIO_push(b64, bio);
+	BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+	
+	decoded_len = BIO_read(bio, output, MAX_AES_XTS_PLAIN_KEYSIZE);
+	BIO_free_all(bio);
+	
+	if (decoded_len < 0) {
+		return -1;
+	}
+	
+	*output_len = decoded_len;
+	return 0;
+}

--- a/vhd/lib/Makefile.am
+++ b/vhd/lib/Makefile.am
@@ -42,7 +42,7 @@ libvhd_la_SOURCES += xattr.h
 
 libvhd_la_LDFLAGS = -version-info 1:1:1
 
-libvhd_la_LIBADD = -luuid -ldl $(LIBICONV)  $(top_srcdir)/lvm/liblvmutil.la
+libvhd_la_LIBADD = -luuid -ldl $(LIBICONV) $(top_builddir)/lib/libblktaputil.la $(top_srcdir)/lvm/liblvmutil.la
 
 if ENABLE_TESTS
 MAYBE_test = test


### PR DESCRIPTION
- Create the base64 encode decode utils
- Enable `tap-ctl -E` , `cbt-util get -b` and `vhd-util read -B` to input/output with base64

BST : 219165