### PR TITLE
CA-414626: initialize cpumon even if lowmem initialization failed

### DIFF
--- a/drivers/tapdisk-server.c
+++ b/drivers/tapdisk-server.c
@@ -765,17 +765,14 @@ tapdisk_server_init(void)
 		EPRINTF("Failed to initialize low memory handler: %s\n",
 		        strerror(-ret));
 		lowmem_cleanup();
-		goto out;
 	}
 
 	if ((ret = tapdisk_server_initialize_cpumond_client()) < 0) {
 		EPRINTF("Failed to connect to cpumond: %s\n",
 			strerror(-ret));
 		cpumond_cleanup();
-		goto out;
 	}
 
-out:
 	server.tlog_reopen_evid = -1;
 
 	return 0;


### PR DESCRIPTION
Low memory monitoring and CPU usage monitoring are used for different purposes: if we fail to initialize one, we should still try to initialize the other.

Low memory monitoring is used to reduce queue depth / buffers allocated when we have a lot of disks attached on the same host.

CPU usage monitoring is used to determine when it is safe to enter busy polling mode: when Dom0 is already under high load then we don't enter busy polling mode to allow other processes to use the CPU. If CPU usage monitoring is not initialized then tapdisk never enter polling mode, which reduces guest I/O performance.

Low memory monitoring currently fails to initialize with a newer kernel CA-400404, which exposed this latent performance bug in tapdisk. We should fix lowmem mode, but for now fix the performance bug.

After this change tapdisk now correctly enters polling mode. There is a separate bug that it won't stay in polling mode long enough, but that'll be fixed in a separate PR.