### PR TITLE
Minor style changes to the code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,10 @@ AC_CHECK_HEADERS([uuid/uuid.h], [], [Need uuid-dev])
 AC_CHECK_HEADERS([libaio.h], [], [Need libaio-dev])
 AC_CHECK_HEADERS([limits.h], [], [AC_MSG_ERROR([cannot find limits.h])])
 AC_CHECK_HEADERS([time.h], [], [AC_MSG_ERROR([cannot find time.h])])
+AC_CHECK_HEADERS([cmocka.h], [], [AC_MSG_ERROR([cannot find cmocka.h])], [[#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>]])
+AC_CHECK_HEADERS([xen/xen.h], [], [AC_MSG_ERROR([cannot find xen/xen.h])])
 
 AC_ARG_WITH([libiconv],
 	     [AS_HELP_STRING([--with-libiconv],

--- a/drivers/atomicio.c
+++ b/drivers/atomicio.c
@@ -36,11 +36,7 @@
  * ensure all of data on socket comes through. f==read || f==vwrite
  */
 size_t
-atomicio(f, fd, _s, n)
-	ssize_t (*f) (int, void *, size_t);
-	int fd;
-	void *_s;
-	size_t n;
+atomicio(ssize_t (*f) (int, void *, size_t), int fd, void *_s, size_t n)
 {
 	char *s = _s;
 	size_t pos = 0;

--- a/drivers/libaio-backend.h
+++ b/drivers/libaio-backend.h
@@ -29,7 +29,7 @@
  */
 
 #ifndef LIBAIO_BACKEND_H
-#define LIBAIO_BACLEND_H
+#define LIBAIO_BACKEND_H
 
 #include <libaio.h>
 
@@ -43,4 +43,4 @@ enum {
 
 struct backend* get_libaio_backend();
 
-#endif /* LIBAIO_BACLEND_H */
+#endif /* LIBAIO_BACKEND_H */

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -174,7 +174,7 @@ struct td_xenblkif {
 
 	struct {
 		/**
-		 * Pointer to he pending barrier request.
+		 * Pointer to the pending barrier request.
 		 */
 		blkif_request_t *msg;
 

--- a/include/util.h
+++ b/include/util.h
@@ -42,11 +42,11 @@
 static inline char *
 safe_strncpy(char *dest, const char *src, size_t n)
 {
-	char *pdest;
-	pdest = strncpy(dest, src, n - 1);
-	if (n > 0)
+	if (n > 0) {
+		strncpy(dest, src, n - 1);
 		dest[n - 1] = '\0';
-	return pdest;
+	}
+	return dest;
 }
 
 #endif /* __TAPDISK_UTIL_H__ */

--- a/include/util.h
+++ b/include/util.h
@@ -39,7 +39,7 @@
 /*
  * Strncpy variant that guarantees to terminate the string
  */
-static inline char *
+static inline void
 safe_strncpy(char *dest, const char *src, size_t n)
 {
 #ifdef __GNUC__
@@ -53,7 +53,6 @@ safe_strncpy(char *dest, const char *src, size_t n)
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
-	return dest;
 }
 
 #endif /* __TAPDISK_UTIL_H__ */

--- a/include/util.h
+++ b/include/util.h
@@ -29,7 +29,7 @@
  */
 
 #ifndef __TAPDISK_UTIL_H__
-#define __TAPDISK_UTIL_H_
+#define __TAPDISK_UTIL_H__
 
 #include <stddef.h>
 #include <string.h>

--- a/include/util.h
+++ b/include/util.h
@@ -42,10 +42,17 @@
 static inline char *
 safe_strncpy(char *dest, const char *src, size_t n)
 {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 	if (n > 0) {
 		strncpy(dest, src, n - 1);
 		dest[n - 1] = '\0';
 	}
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 	return dest;
 }
 

--- a/vhd/lib/atomicio.c
+++ b/vhd/lib/atomicio.c
@@ -36,11 +36,7 @@
  * ensure all of data on socket comes through. f==read || f==vwrite
  */
 size_t
-atomicio(f, fd, _s, n)
-	ssize_t (*f) (int, void *, size_t);
-	int fd;
-	void *_s;
-	size_t n;
+atomicio(ssize_t (*f) (int, void *, size_t), int fd, void *_s, size_t n)
 {
 	char *s = _s;
 	size_t pos = 0;


### PR DESCRIPTION
Summary
- Fix file guards spellings
- Update definitions to use ANSI style
- Check all required headers are present during configuration
- Avoid crash calling `safe_strncpy` with zero size
- Ignore warnings calling `strncpy`
- Remove unused return value from `safe_strncpy`
- Fix typo in comment

Mostly detected by a more recent compiler.
