### PR TITLE
blktap: change MAINTAINERS to switch maintenance to Vates

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,13 +1,12 @@
 Maintainers list
 ----------------
 
-The project is maintained by many people but as a reference
-person contact
+The project is maintained by
 
-* Mark Syms <mark.syms@citrix.com>
+* Ronan Abhamon <ronan.abhamon@vates.tech>
+* Damien Thenot <damien.thenot@vates.tech>
+* Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
 
-while for technical discussions of general interest
-use the public mailing lists
+Issues and pull requests can be created at
 
-* xs-devel@lists.xenserver.org
-* xen-api@lists.xen.org 
+* https://github.com/xapi-project/blktap


### PR DESCRIPTION
As discussed with the current maintainers, this commit will change maintainers of blktap component to @Wescoeur, @Nambrok and @AnthoineB (same order as in MAINTAINERS file and same list as SM https://github.com/xapi-project/sm/pull/801).