### PR TITLE
CA-395093: miss physical-device-path xenstore key

### DIFF
--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -769,6 +769,18 @@ reconnect(vbd_t *device) {
         }
     }
 
+    err = physical_device_path_changed(device);
+    if (err) {
+        if (err == -ENOENT) {
+            DBG(device, "no physical device path yet\n");
+            err = 0;
+        } else {
+            WARN(device, "failed to retrieve physical device path: "
+                    "%s\n", strerror(-err));
+            goto out;
+        }
+    }
+
     err = hotplug_status_changed(device);
     if (err) {
         if (err == -ENOENT) {


### PR DESCRIPTION
read physical-device-path from xenstore directly, there is no synchronization between slave tapback process and xenopsd hotplug vbd-script, so, in some corner case, slave tapback process would miss physical-device-path xenstore watch event, then blktap io datapath fails to be established.